### PR TITLE
Raise warning messages for using Gradle 1.x.

### DIFF
--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBasePlugin.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBasePlugin.groovy
@@ -16,6 +16,7 @@
 package com.asakusafw.gradle.plugins
 
 import org.gradle.api.*
+import org.gradle.util.GradleVersion
 
 import com.asakusafw.gradle.plugins.internal.AsakusafwInternalPluginConvention
 
@@ -28,6 +29,10 @@ class AsakusafwBasePlugin implements Plugin<Project> {
 
     void apply(Project project) {
         this.project = project
+        if (GradleVersion.current() < GradleVersion.version('2.0')) {
+            project.logger.warn "Asakusa Framework Gradle plug-ins recommend using Gradle 2.0 or later"
+            project.logger.warn "The current Gradle version (${GradleVersion.current()}) will not be supported in future releases"
+        }
         configureProject()
     }
 


### PR DESCRIPTION
With using Gradle `1.12`, Asakusa Gradle plug-in will show the following messages.

```
Asakusa Framework Gradle plug-ins recommend using Gradle 2.0 or later
The current Gradle version (Gradle 1.12) will not be supported in future releases
```