### PR TITLE
Map type properties should ignore entries with null value.

### DIFF
--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/tasks/internal/ResolutionUtils.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/tasks/internal/ResolutionUtils.groovy
@@ -57,12 +57,19 @@ final class ResolutionUtils {
         return results
     }
 
+    /**
+     * Resolves value map into a map which strings maps to strings.
+     * If key or value is null in original map, the resulting map does not contain it.
+     * @param value the target values
+     * @return the resolved string list
+     */
     static Map<String, String> resolveToStringMap(Map<?, ?> values) {
         Map<String, String> results = [:]
         for (Map.Entry<?, ?> entry in values.entrySet()) {
             String key = resolveToString(entry.key)
-            if (key != null) {
-                results.put key, resolveToString(entry.value)
+            String value = resolveToString(entry.value)
+            if (key != null && value != null) {
+                results.put key, value
             }
         }
         return results

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/test/groovy/com/asakusafw/gradle/tasks/internal/ResolutionUtilsTest.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/test/groovy/com/asakusafw/gradle/tasks/internal/ResolutionUtilsTest.groovy
@@ -144,6 +144,6 @@ class ResolutionUtilsTest {
         origin.put({ null }, 'v3')
 
         Map<String, String> values = ResolutionUtils.resolveToStringMap(origin)
-        assert values == ['k1' : '100', 'k2' : null]
+        assert values == ['k1' : '100']
     }
 }


### PR DESCRIPTION
## Summary

Map type properties (e.g. `asakusafw.{mapreduce, ...}.compilerProperties`) become to ignore entries with `null` value (entries with `null` **key** have been already ignored).

## Background, Problem or Goal of the patch

For example, the following snippet passes `-Dx=null` to DMDL compiler, if system property `x` is not defined.

```groovy
compileDMDL.systemProperties['x'] = System.getProperties('x')
```

This may be wrong if the target system cannot recognize a string `"null"` for `x` option. To avoid the above problem, it had been required to write like the following:

```groovy
if (System.getProperties('X') != null)
    compileDMDL.systemProperties['x'] = System.getProperties('x')
```

This commit fixes the above problem, application developers now can write simply like the first snippet.

Or to put explicitly `null` value when it is not defined, delopers must write as like the following:
```groovy
compileDMDL.systemProperties['x'] = System.getProperties('x', 'null')
```

## Design of the fix, or a new feature

I just fixed `ResolutionUtil.resolveToStringMap()`, which converts `Map<?, ?>` into `Map<String, String>` and filters invalid entries. This method is referred from several plugins/tasks.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 
