### PR TITLE
Introduce `AsakusafwCompilerExtension.options`.

### DIFF
--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwCompilerExtension.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwCompilerExtension.groovy
@@ -18,7 +18,7 @@ package com.asakusafw.gradle.plugins
 /**
  * An extension object for Asakusa DSL compiler framework.
  * @since 0.7.4
- * @version 0.8.0
+ * @version 0.8.1
  */
 class AsakusafwCompilerExtension {
 
@@ -59,4 +59,62 @@ class AsakusafwCompilerExtension {
      * Whether fails on compilation errors or not.
      */
     boolean failOnError
+
+    /**
+     * Adds compiler properties.
+     * @param additions the additional compiler properties
+     * @since 0.8.1
+     */
+    void compilerProperties(Map<?, ?> additions) {
+        additions.each { k, v ->
+            compilerProperty(k, v)
+        }
+    }
+
+    /**
+     * Adds a compiler property.
+     * @param additionalOptions the additional compiler properties
+     * @since 0.8.1
+     */
+    void compilerProperty(Object key, Object value) {
+        getCompilerProperties().put(key, value)
+    }
+
+    /**
+     * Returns the compiler properties.
+     * This is alias of {@link #compilerProperties}.
+     * @return the current compiler properties
+     * @since 0.8.1
+     */
+    Map<Object, Object> getOptions() {
+        return getCompilerProperties()
+    }
+
+    /**
+     * Sets the compiler properties.
+     * This is alias of {@link #compilerProperties}.
+     * @param options the map of compiler properties
+     * @since 0.8.1
+     */
+    void setOptions(Map<?, ?> options) {
+        setCompilerProperties(new LinkedHashMap<>(options))
+    }
+
+    /**
+     * Adds compiler properties.
+     * @param additions the additional compiler properties
+     * @since 0.8.1
+     */
+    void options(Map<?, ?> additions) {
+        compilerProperties(additions)
+    }
+
+    /**
+     * Adds a compiler property.
+     * @param additionalOptions the additional compiler properties
+     * @since 0.8.1
+     */
+    void option(Object key, Object value) {
+        compilerProperty(key, value)
+    }
 }

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/tasks/AsakusaCompileTask.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/tasks/AsakusaCompileTask.groovy
@@ -35,6 +35,7 @@ import com.asakusafw.gradle.tasks.internal.ToolLauncherUtils
 /**
  * Gradle Task for Asakusa DSL compiler framework.
  * @since 0.8.0
+ * @version 0.8.1
  */
 class AsakusaCompileTask extends DefaultTask {
 
@@ -312,6 +313,17 @@ class AsakusaCompileTask extends DefaultTask {
     @Option(option = 'compiler-properties', description = 'extra compiler properties separated by comma')
     void setExtraCompilerPropertiesOption(String encoded) {
         getCompilerProperties().putAll(decodeMap(encoded))
+    }
+
+    /**
+     * Adds extra {@link #compilerProperties compiler properties}.
+     * This is an alias of {@link #setExtraCompilerPropertiesOption(String)}.
+     * @param encoded the encoded {@code key=value} entries separated by comma
+     * @since 0.8.1
+     */
+    @Option(option = 'options', description = 'extra compiler properties separated by comma')
+    void setExtraCompilerOptionsOption(String encoded) {
+        setExtraCompilerPropertiesOption(encoded)
     }
 
     /**

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/test/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkPluginTest.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/test/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkPluginTest.groovy
@@ -98,6 +98,21 @@ class AsakusaMapReduceSdkPluginTest {
     }
 
     /**
+     * Test for {@code project.asakusafw.mapreduce.options}.
+     */
+    @Test
+    void extension_options() {
+        project.asakusafw.mapreduce.options = [:]
+        project.asakusafw.mapreduce.options 'a': true, 'b': false, 'Xc': 'd'
+        project.asakusafw.mapreduce.options 'e': true
+        project.asakusafw.mapreduce.option 'f', false
+
+        Map<String, String> map = ResolutionUtils.resolveToStringMap(project.asakusafw.mapreduce.options)
+        assert map == ['a': 'true', 'b': 'false', 'Xc': 'd', 'e': 'true', 'f': 'false']
+        assert map == ResolutionUtils.resolveToStringMap(project.asakusafw.mapreduce.compilerProperties)
+    }
+
+    /**
      * Test for {@code project.tasks.mapreduceCompileBatchapps}.
      */
     @Test


### PR DESCRIPTION
## Summary

This commit enables to use `AsakusafwCompilerExtension.options` as a alias of `AsakusafwCompilerExtension.compilerProperties`.

## Background, Problem or Goal of the patch

"compiler properties" is the official term of Asakusa DSL compiler, but is sometimes too long for build scripts.

## Design of the fix, or a new feature

The introduced property is just an alias of the present `.compilerProperties`.
This commit also introduces the following methods are available:

* `options(Map)` - adds a set of properties
* `option(Object, Object)` - adds a property
* CLI option: `--options` - alias of `--compiler-properties` for on {Spark, M3BP}

These features may make build scripts more simple.

```groovy
asakusafw {
  // adds a compiler property
  mapreduce.option 'enableDebugLogging', true
}
```

## Related Issue, Pull Request or Code

N/A

## Wanted reviewer

@akirakw 