### PR TITLE
Fix organizer artifact configuration about Hive.

### DIFF
--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusafwOrganizer.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusafwOrganizer.groovy
@@ -173,7 +173,10 @@ class AsakusafwOrganizer extends AbstractOrganizer {
                     "org.slf4j:slf4j-api:${base.slf4jVersion}@jar",
                 ],
                 DirectIoHiveDist : [],
-                DirectIoHiveLib : ["com.asakusafw:asakusa-hive-core:${frameworkVersion}@jar"] + profile.hive.libraries,
+                DirectIoHiveLib : [
+                    "com.asakusafw:asakusa-hive-info:${frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-hive-core:${frameworkVersion}@jar",
+                ] + profile.hive.libraries,
                 ExtensionLib : profile.extension.libraries,
             ])
         }


### PR DESCRIPTION
## Summary

This commit fixes organizer artifact configuration about Hive.

## Background, Problem or Goal of the patch

In asakusafw/asakusafw#624, we added `asakusa-hive-info` but the current framework organizer does not includes it into deployment archives.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#624

## Wanted reviewer

@akirakw