### PR TITLE
Changing `*.asakusafwVersion` is now deprecated.

### DIFF
--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPlugin.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPlugin.groovy
@@ -133,7 +133,7 @@ class AsakusafwOrganizerPlugin  implements Plugin<Project> {
         }
 
         convention.metaClass.toStringDelegate = { -> "asakusafwOrganizer { ... }" }
-        PluginUtils.deprecateAsakusafwVersion project, 'asakusafwOrganizer.', convention
+        PluginUtils.deprecateAsakusafwVersion project, 'asakusafwOrganizer', convention
     }
 
     private NamedDomainObjectContainer<AsakusafwOrganizerProfile> createProfileContainer(AsakusafwOrganizerPluginConvention convention) {
@@ -205,7 +205,7 @@ class AsakusafwOrganizerPlugin  implements Plugin<Project> {
         profile.extension.conventionMapping.with {
             defaultLibraries = { convention.extension.libraries }
         }
-        PluginUtils.deprecateAsakusafwVersion project, "asakusafwOrganizer.profiles.${profile.name}.", convention
+        PluginUtils.deprecateAsakusafwVersion project, "asakusafwOrganizer.profiles.${profile.name}", profile
     }
 
     private void configureProfiles() {

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPlugin.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPlugin.groovy
@@ -133,6 +133,7 @@ class AsakusafwOrganizerPlugin  implements Plugin<Project> {
         }
 
         convention.metaClass.toStringDelegate = { -> "asakusafwOrganizer { ... }" }
+        PluginUtils.deprecateAsakusafwVersion project, 'asakusafwOrganizer.', convention
     }
 
     private NamedDomainObjectContainer<AsakusafwOrganizerProfile> createProfileContainer(AsakusafwOrganizerPluginConvention convention) {
@@ -204,6 +205,7 @@ class AsakusafwOrganizerPlugin  implements Plugin<Project> {
         profile.extension.conventionMapping.with {
             defaultLibraries = { convention.extension.libraries }
         }
+        PluginUtils.deprecateAsakusafwVersion project, "asakusafwOrganizer.profiles.${profile.name}.", convention
     }
 
     private void configureProfiles() {

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
@@ -137,7 +137,7 @@ class AsakusaSdkPlugin implements Plugin<Project> {
             testDataSheetFormat = { 'ALL' }
             testDataSheetDirectory = { (String) "${project.buildDir}/excel" }
         }
-        PluginUtils.deprecateAsakusafwVersion project, 'asakusafw.', extension
+        PluginUtils.deprecateAsakusafwVersion project, 'asakusafw', extension
         extension.metaClass.toStringDelegate = { -> "asakusafw { ... }" }
     }
 

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
@@ -137,6 +137,7 @@ class AsakusaSdkPlugin implements Plugin<Project> {
             testDataSheetFormat = { 'ALL' }
             testDataSheetDirectory = { (String) "${project.buildDir}/excel" }
         }
+        PluginUtils.deprecateAsakusafwVersion project, 'asakusafw.', extension
         extension.metaClass.toStringDelegate = { -> "asakusafw { ... }" }
     }
 

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/internal/PluginUtils.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/internal/PluginUtils.groovy
@@ -112,9 +112,14 @@ final class PluginUtils {
             return getter()
         }
         def setter = instance.&setAsakusafwVersion
-        instance.metaClass.setAsakusafwVersion = { args ->
-            project.logger.warn "changing ${prefix}asakusafwVersion is deprecated"
-            setter(args)
+        instance.metaClass.setAsakusafwVersion = { String arg ->
+            project.logger.warn "changing ${prefix}.asakusafwVersion is deprecated."
+            setter(arg)
+        }
+        // asakusafwVersion(String) does not via Groovy MOP when calls setAsakusafwVersion()
+        instance.metaClass.asakusafwVersion = { String arg ->
+            project.logger.warn "changing ${prefix}.asakusafwVersion is deprecated."
+            setter(arg)
         }
         return instance
     }

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/internal/PluginUtils.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/internal/PluginUtils.groovy
@@ -113,12 +113,12 @@ final class PluginUtils {
         }
         def setter = instance.&setAsakusafwVersion
         instance.metaClass.setAsakusafwVersion = { String arg ->
-            project.logger.warn "changing ${prefix}.asakusafwVersion is deprecated."
+            project.logger.warn "DEPRECATED: changing ${prefix}.asakusafwVersion is deprecated."
             setter(arg)
         }
         // asakusafwVersion(String) does not via Groovy MOP when calls setAsakusafwVersion()
         instance.metaClass.asakusafwVersion = { String arg ->
-            project.logger.warn "changing ${prefix}.asakusafwVersion is deprecated."
+            project.logger.warn "DEPRECATED: changing ${prefix}.asakusafwVersion is deprecated."
             setter(arg)
         }
         return instance

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/internal/PluginUtils.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/internal/PluginUtils.groovy
@@ -17,13 +17,13 @@ package com.asakusafw.gradle.plugins.internal
 
 import org.gradle.api.Project
 import org.gradle.api.ProjectState
-import org.gradle.api.Task;
+import org.gradle.api.Task
 import org.gradle.util.GradleVersion
 
 /**
  * Basic utilities for Gradle plug-ins.
  * @since 0.7.4
- * @version 0.8.0
+ * @version 0.8.1
  */
 final class PluginUtils {
 
@@ -95,6 +95,28 @@ final class PluginUtils {
         }.all { Task t ->
             closure.call(t)
         }
+    }
+
+    /**
+     * Make modifying <code>asakusafwVersion</code> deprecated.
+     * @param project the current project
+     * @param prefix the instance prefix name
+     * @param instance the target instance
+     * @return the original instance
+     * @since 0.8.1
+     */
+    static <T> T deprecateAsakusafwVersion(Project project, String prefix, T instance) {
+        // must declare getter explicitly for older Gradle versions (e.g. 1.12)
+        def getter = instance.&getAsakusafwVersion
+        instance.metaClass.getAsakusafwVersion = { ->
+            return getter()
+        }
+        def setter = instance.&setAsakusafwVersion
+        instance.metaClass.setAsakusafwVersion = { args ->
+            project.logger.warn "changing ${prefix}asakusafwVersion is deprecated"
+            setter(args)
+        }
+        return instance
     }
 
     private PluginUtils() {


### PR DESCRIPTION
## Summary

This commit enables to raise warning messages on changing `asakusafwVersion`.

## Background, Problem or Goal of the patch

From ver. `0.8.0`, setting custom version to the following properties is not recommended:
* `asakusafw.asakusafwVersion`
* `asakusafwOrganizer.asakusafwVersion`
* `asakusafwOrganizer.profiles.*.asakusafwVersion`

Changing the above properties may break down artifacts consistency.

## Design of the fix, or a new feature

This commit just raise warning log when `asakusafwVersion` properties were changed, but they still can be changed.

To use another version of Asakusa Framework, developers should change applying plug-ins version instead of setting the above properties.

## Related Issue, Pull Request or Code

* #94

## Wanted reviewer

@akirakw