### PR TITLE
Separate core and legacy module versions

### DIFF
--- a/gradle-sdk-project/asakusa-gradle-plugins/build.gradle
+++ b/gradle-sdk-project/asakusa-gradle-plugins/build.gradle
@@ -21,6 +21,7 @@ ext.parentPom = { f ->
     return [
         projectVersion : xml.version.text(),
         coreVersion : xml['properties']['asakusafw.version'].text().replaceFirst('-hadoop[12]', ''),
+        legacyVersion : xml['properties']['asakusafw-legacy.version'].text(),
     ]
 }(project.file('../../pom.xml'))
 
@@ -82,6 +83,25 @@ processResources {
         Properties p = new Properties()
         p.put("plugin-version", parentPom.projectVersion)
         p.put("framework-version", parentPom.coreVersion)
+        outputFile.withOutputStream { s ->
+            p.store(s, null)
+        }
+    }
+}
+
+processResources {
+    File outputFile = new File(destinationDir, 'META-INF/asakusa-legacy-gradle/artifact.properties')
+    inputs.properties parentPom
+    outputs.file outputFile
+    doLast {
+        logger.info "injecting artifact versions: ${parentPom}"
+        if (!outputFile.parentFile.exists()) {
+            mkdir outputFile.parentFile
+        }
+        Properties p = new Properties()
+        p.put('feature-version', parentPom.legacyVersion)
+        p.put("core-version", parentPom.coreVersion)
+        p.put("sdk-version", parentPom.projectVersion)
         outputFile.withOutputStream { s ->
             p.store(s, null)
         }

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBaseExtension.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBaseExtension.groovy
@@ -19,6 +19,7 @@ package com.asakusafw.gradle.plugins
  * An extension object for the Asakusa features.
  * This is only for internal use.
  * @since 0.8.0
+ * @version 0.8.1
  */
 class AsakusafwBaseExtension {
 
@@ -58,11 +59,6 @@ class AsakusafwBaseExtension {
     String logbackVersion
 
     /**
-     * The default Log4J version.
-     */
-    String log4jVersion
-
-    /**
      * The default JSCH version.
      */
     String jschVersion
@@ -88,11 +84,6 @@ class AsakusafwBaseExtension {
     String commonsCodecVersion
 
     /**
-     * The default Commons Configuration version.
-     */
-    String commonsConfigurationVersion
-
-    /**
      * The default Commons IO version.
      */
     String commonsIoVersion
@@ -106,11 +97,6 @@ class AsakusafwBaseExtension {
      * The default Commons Logging version.
      */
     String commonsLoggingVersion
-
-    /**
-     * The default MySQL Connector/J version.
-     */
-    String mysqlConnectorJavaVersion
 
     /**
      * The default Hive artifact notation.

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBasePlugin.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBasePlugin.groovy
@@ -99,7 +99,6 @@ class AsakusafwBasePlugin implements Plugin<Project> {
             'embedded-libs-directory': 'embeddedd libraries directory',
             'slf4j-version': 'SLF4J',
             'logback-version': 'Logback',
-            'log4j-version': 'Log4J',
             'jsch-version': 'JSch',
             'gson-version': 'GSON',
             'http-client-version': 'Commons HTTP Client',
@@ -107,9 +106,7 @@ class AsakusafwBasePlugin implements Plugin<Project> {
             'commons-io-version': 'Commons IO',
             'commons-lang-version': 'Commons Lang',
             'commons-codec-version': 'Commons Codec',
-            'commons-configuration-version': 'Commons Configuration',
             'commons-logging-version': 'Commons Logging',
-            'mysql-connector-java-version': 'MySQL Connector/J',
             'hive-artifact': 'Hive',
         ])
     }

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/legacy/gradle/plugins/internal/AsakusaLegacyBaseExtension.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/legacy/gradle/plugins/internal/AsakusaLegacyBaseExtension.groovy
@@ -36,4 +36,34 @@ class AsakusaLegacyBaseExtension {
      * The SDK libraries version.
      */
     String sdkVersion
+
+    /**
+     * The default Commons Configuration version.
+     */
+    String commonsConfigurationVersion
+
+    /**
+     * The default Commons IO version.
+     */
+    String commonsIoVersion
+
+    /**
+     * The default Commons Lang version.
+     */
+    String commonsLangVersion
+
+    /**
+     * The default Commons Logging version.
+     */
+    String commonsLoggingVersion
+
+    /**
+     * The default Log4J version.
+     */
+    String log4jVersion
+
+    /**
+     * The default MySQL Connector/J version.
+     */
+    String mysqlConnectorJavaVersion
 }

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/legacy/gradle/plugins/internal/AsakusaLegacyBaseExtension.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/legacy/gradle/plugins/internal/AsakusaLegacyBaseExtension.groovy
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.legacy.gradle.plugins.internal
+
+/**
+ * An extension object for the Asakusa legacy features.
+ * This is only for internal use.
+ * @since 0.8.1
+ */
+class AsakusaLegacyBaseExtension {
+
+    /**
+     * The legacy project version.
+     */
+    String featureVersion
+
+    /**
+     * The core libraries version.
+     */
+    String coreVersion
+
+    /**
+     * The SDK libraries version.
+     */
+    String sdkVersion
+}

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/legacy/gradle/plugins/internal/AsakusaLegacyBasePlugin.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/legacy/gradle/plugins/internal/AsakusaLegacyBasePlugin.groovy
@@ -1,0 +1,132 @@
+/*
+ * Copyright 2011-2016 Asakusa Framework Team.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.asakusafw.legacy.gradle.plugins.internal
+
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+
+import com.asakusafw.gradle.plugins.AsakusafwBasePlugin
+
+/**
+ * A Gradle base plug-in for Asakusa legacy modules.
+ * @since 0.8.1
+ */
+class AsakusaLegacyBasePlugin implements Plugin<Project> {
+
+    private static final String ARTIFACT_INFO_PATH = 'META-INF/asakusa-legacy-gradle/artifact.properties'
+
+    private static final String INVALID_VERSION = 'INVALID'
+
+    private Project project
+
+    private AsakusaLegacyBaseExtension extension
+
+    /**
+     * Applies this plug-in and returns the extension object for the project.
+     * @param project the target project
+     * @return the corresponded extension
+     */
+    static AsakusaLegacyBaseExtension get(Project project) {
+        project.apply plugin: AsakusaLegacyBasePlugin
+        return project.plugins.getPlugin(AsakusaLegacyBasePlugin).extension
+    }
+
+    @Override
+    void apply(Project project) {
+        this.project = project
+        this.extension = project.extensions.create('asakusaLegacyBase', AsakusaLegacyBaseExtension)
+        configureExtension()
+        configureTasks()
+    }
+
+    private void configureExtension() {
+        configureArtifactVersions()
+    }
+
+    private void configureArtifactVersions() {
+        Properties properties = loadProperties(ARTIFACT_INFO_PATH)
+        driveProperties(ARTIFACT_INFO_PATH, [
+            'feature-version': 'Asakusa Legacy modules',
+            'core-version': 'Asakusa Core libraries',
+            'sdk-version': 'Asakusa SDK',
+        ])
+        project.logger.info "Asakusa Legacy modules: ${extension.featureVersion}"
+    }
+
+    private void driveProperties(String path, Map<String, String> configurations) {
+        Properties properties = loadProperties(path)
+        configurations.each { String key, String name ->
+            StringBuilder buf = new StringBuilder()
+            boolean sawHyphen = false
+            for (char c : key.toCharArray()) {
+                if (c == '-') {
+                    sawHyphen = true
+                } else {
+                    buf.append(sawHyphen ? Character.toUpperCase(c) : c)
+                    sawHyphen = false
+                }
+            }
+            String prop = buf.toString()
+            assert extension.hasProperty(prop)
+            extension[prop] = extract(properties, key, name)
+        }
+    }
+
+    private String extract(Properties properties, String key, String name) {
+        String value = properties.getProperty(key, INVALID_VERSION)
+        if (value == INVALID_VERSION) {
+            project.logger.warn "failed to detect version of ${name}"
+        } else {
+            project.logger.info "${name} version: ${value}"
+        }
+        return value
+    }
+
+    private Properties loadProperties(String path) {
+        Properties results = new Properties()
+        InputStream input = getClass().classLoader.getResourceAsStream(path)
+        if (input == null) {
+            project.logger.warn "missing properties file: ${path}"
+        } else {
+            try {
+                results.load(input)
+            } catch (IOException e) {
+                project.logger.warn "error occurred while extracting properties: ${path}"
+            } finally {
+                input.close()
+            }
+        }
+        return results
+    }
+
+    private void configureTasks() {
+        extendVersionsTask()
+    }
+
+    private void extendVersionsTask() {
+        project.tasks.getByName(AsakusafwBasePlugin.TASK_VERSIONS) << {
+            logger.lifecycle "Asakusa Legacy modules: ${extension.featureVersion}"
+        }
+    }
+
+    /**
+     * Returns the extension.
+     * @return the extension
+     */
+    AsakusaLegacyBaseExtension getExtension() {
+        return extension
+    }
+}

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/legacy/gradle/plugins/internal/AsakusaLegacyBasePlugin.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/legacy/gradle/plugins/internal/AsakusaLegacyBasePlugin.groovy
@@ -26,7 +26,11 @@ import com.asakusafw.gradle.plugins.AsakusafwBasePlugin
  */
 class AsakusaLegacyBasePlugin implements Plugin<Project> {
 
-    private static final String ARTIFACT_INFO_PATH = 'META-INF/asakusa-legacy-gradle/artifact.properties'
+    private static final String PREFIX_INFO_PATH = 'META-INF/asakusa-legacy-gradle/'
+
+    private static final String ARTIFACT_INFO_PATH = PREFIX_INFO_PATH + 'artifact.properties'
+
+    private static final String DEFAULTS_INFO_PATH = PREFIX_INFO_PATH + 'defaults.properties'
 
     private static final String INVALID_VERSION = 'INVALID'
 
@@ -54,6 +58,7 @@ class AsakusaLegacyBasePlugin implements Plugin<Project> {
 
     private void configureExtension() {
         configureArtifactVersions()
+        configureDefaults()
     }
 
     private void configureArtifactVersions() {
@@ -64,6 +69,17 @@ class AsakusaLegacyBasePlugin implements Plugin<Project> {
             'sdk-version': 'Asakusa SDK',
         ])
         project.logger.info "Asakusa Legacy modules: ${extension.featureVersion}"
+    }
+
+    private void configureDefaults() {
+        driveProperties(DEFAULTS_INFO_PATH, [
+            'commons-configuration-version': 'Commons Configuration',
+            'commons-io-version': 'Commons IO',
+            'commons-lang-version': 'Commons Lang',
+            'commons-logging-version': 'Commons Logging',
+            'log4j-version': 'Log4J',
+            'mysql-connector-java-version': 'MySQL Connector/J',
+        ])
     }
 
     private void driveProperties(String path, Map<String, String> configurations) {

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/legacy/gradle/plugins/internal/AsakusaLegacyOrganizer.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/legacy/gradle/plugins/internal/AsakusaLegacyOrganizer.groovy
@@ -16,10 +16,7 @@
 package com.asakusafw.legacy.gradle.plugins.internal
 
 import org.gradle.api.Project
-import org.gradle.api.Task
 
-import com.asakusafw.gradle.plugins.AsakusafwBaseExtension
-import com.asakusafw.gradle.plugins.AsakusafwBasePlugin
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerProfile
 import com.asakusafw.gradle.plugins.internal.AbstractOrganizer
 import com.asakusafw.gradle.plugins.internal.PluginUtils
@@ -53,10 +50,9 @@ class AsakusaLegacyOrganizer extends AbstractOrganizer {
             DevelopmentDist : "Contents of Asakusa Framework development tools (${profile.name}).",
         ])
         PluginUtils.afterEvaluate(project) {
-            String frameworkVersion = profile.asakusafwVersion
-            AsakusafwBaseExtension base = AsakusafwBasePlugin.get(project)
+            AsakusaLegacyBaseExtension base = AsakusaLegacyBasePlugin.get(project)
             createDependencies('asakusafw', [
-                DevelopmentDist : "com.asakusafw:asakusa-development-tools:${frameworkVersion}:dist@jar",
+                DevelopmentDist : "com.asakusafw:asakusa-development-tools:${base.featureVersion}:dist@jar",
             ])
         }
     }

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/legacy/gradle/plugins/internal/AsakusaLegacyOrganizerPlugin.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/legacy/gradle/plugins/internal/AsakusaLegacyOrganizerPlugin.groovy
@@ -40,6 +40,7 @@ class AsakusaLegacyOrganizerPlugin implements Plugin<Project> {
         this.organizers = project.container(AsakusaLegacyOrganizer)
 
         project.apply plugin: 'asakusafw-organizer'
+        project.apply plugin: AsakusaLegacyBasePlugin
 
         configureConvention()
         configureProfiles()

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/thundergate/gradle/plugins/internal/AsakusaThunderGateOrganizer.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/thundergate/gradle/plugins/internal/AsakusaThunderGateOrganizer.groovy
@@ -16,13 +16,12 @@
 package com.asakusafw.thundergate.gradle.plugins.internal
 
 import org.gradle.api.Project
-import org.gradle.api.Task
 
-import com.asakusafw.gradle.plugins.AsakusafwBaseExtension
-import com.asakusafw.gradle.plugins.AsakusafwBasePlugin
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerProfile
 import com.asakusafw.gradle.plugins.internal.AbstractOrganizer
 import com.asakusafw.gradle.plugins.internal.PluginUtils
+import com.asakusafw.legacy.gradle.plugins.internal.AsakusaLegacyBaseExtension
+import com.asakusafw.legacy.gradle.plugins.internal.AsakusaLegacyBasePlugin
 import com.asakusafw.thundergate.gradle.plugins.AsakusafwOrganizerThunderGateExtension
 
 /**
@@ -58,12 +57,11 @@ class AsakusaThunderGateOrganizer extends AbstractOrganizer {
         ])
         configuration('asakusafwThunderGateCoreLib').transitive = false
         PluginUtils.afterEvaluate(project) {
-            String frameworkVersion = profile.asakusafwVersion
-            AsakusafwBaseExtension base = AsakusafwBasePlugin.get(project)
+            AsakusaLegacyBaseExtension base = AsakusaLegacyBasePlugin.get(project)
             createDependencies('asakusafw', [
-                ThunderGateDist : "com.asakusafw:asakusa-thundergate:${frameworkVersion}:dist@jar",
+                ThunderGateDist : "com.asakusafw:asakusa-thundergate:${base.featureVersion}:dist@jar",
                 ThunderGateLib : [
-                    "com.asakusafw:asakusa-thundergate:${frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-thundergate:${base.featureVersion}@jar",
                     "commons-configuration:commons-configuration:${base.commonsConfigurationVersion}@jar",
                     "commons-io:commons-io:${base.commonsIoVersion}@jar",
                     "commons-lang:commons-lang:${base.commonsLangVersion}@jar",
@@ -72,7 +70,7 @@ class AsakusaThunderGateOrganizer extends AbstractOrganizer {
                     "mysql:mysql-connector-java:${base.mysqlConnectorJavaVersion}@jar",
                 ],
                 ThunderGateCoreLib : [
-                    "com.asakusafw:asakusa-thundergate-runtime:${frameworkVersion}@jar"
+                    "com.asakusafw:asakusa-thundergate-runtime:${base.featureVersion}@jar"
                 ],
             ])
         }

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/thundergate/gradle/plugins/internal/AsakusaThunderGateOrganizerPlugin.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/thundergate/gradle/plugins/internal/AsakusaThunderGateOrganizerPlugin.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.Task
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPlugin
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerProfile
+import com.asakusafw.legacy.gradle.plugins.internal.AsakusaLegacyBasePlugin
 import com.asakusafw.thundergate.gradle.plugins.AsakusafwOrganizerThunderGateExtension
 
 /**
@@ -41,6 +42,7 @@ class AsakusaThunderGateOrganizerPlugin implements Plugin<Project> {
         this.organizers = project.container(AsakusaThunderGateOrganizer)
 
         project.apply plugin: 'asakusafw-organizer'
+        project.apply plugin: AsakusaLegacyBasePlugin
 
         configureConvention()
         configureProfiles()

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/thundergate/gradle/plugins/internal/AsakusaThunderGateSdkPlugin.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/thundergate/gradle/plugins/internal/AsakusaThunderGateSdkPlugin.groovy
@@ -29,6 +29,8 @@ import com.asakusafw.gradle.plugins.internal.AsakusaSdk
 import com.asakusafw.gradle.plugins.internal.AsakusaSdkPlugin
 import com.asakusafw.gradle.plugins.internal.PluginUtils
 import com.asakusafw.gradle.tasks.GenerateThunderGateDataModelTask
+import com.asakusafw.legacy.gradle.plugins.internal.AsakusaLegacyBaseExtension
+import com.asakusafw.legacy.gradle.plugins.internal.AsakusaLegacyBasePlugin
 import com.asakusafw.thundergate.gradle.plugins.AsakusafwSdkThunderGateExtension
 
 /**
@@ -44,9 +46,11 @@ class AsakusaThunderGateSdkPlugin implements Plugin<Project> {
     @Override
     void apply(Project project) {
         this.project = project
-        this.extension = AsakusaSdkPlugin.get(project).extensions.create('thundergate', AsakusafwSdkThunderGateExtension)
 
-        project.apply plugin: AsakusaSdkPlugin
+        project.apply plugin: 'asakusafw-sdk'
+        project.apply plugin: AsakusaLegacyBasePlugin
+        extension = AsakusaSdkPlugin.get(project).extensions.create('thundergate', AsakusafwSdkThunderGateExtension)
+
         configureConvention()
         configureConfigurations()
         configureSourceSets()
@@ -78,9 +82,9 @@ class AsakusaThunderGateSdkPlugin implements Plugin<Project> {
             }
         }
         PluginUtils.afterEvaluate(project) {
-            AsakusafwPluginConvention sdk = AsakusaSdkPlugin.get(project)
+            AsakusaLegacyBaseExtension base = AsakusaLegacyBasePlugin.get(project)
             project.dependencies {
-                asakusaThunderGateFiles "com.asakusafw:asakusa-thundergate:${sdk.asakusafwVersion}:dist@jar"
+                asakusaThunderGateFiles "com.asakusafw:asakusa-thundergate:${base.featureVersion}:dist@jar"
             }
         }
     }
@@ -100,6 +104,7 @@ class AsakusaThunderGateSdkPlugin implements Plugin<Project> {
     }
 
     private void defineGenerateThunderGateDataModelTask() {
+        // FIXME: should refer DMDL plug-in versions from the legacy base extension?
         AsakusafwPluginConvention sdk = AsakusaSdkPlugin.get(project)
         project.task('generateThunderGateDataModel', type: GenerateThunderGateDataModelTask) { GenerateThunderGateDataModelTask task ->
             task.group AsakusaSdkPlugin.ASAKUSAFW_BUILD_GROUP

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/resources/META-INF/asakusa-gradle/defaults.properties
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/resources/META-INF/asakusa-gradle/defaults.properties
@@ -6,15 +6,12 @@ embedded-libs-directory=src/main/libs
 ## internal dependencies
 slf4j-version=1.7.10
 logback-version=1.1.3
-log4j-version=1.2.17
 jsch-version=0.1.53
 gson-version=2.5
 http-client-version=4.2.5
 commons-cli-version=1.2
+commons-codec-version=1.10
 commons-io-version=2.4
 commons-lang-version=2.6
-commons-codec-version=1.10
-commons-configuration-version=1.10
 commons-logging-version=1.2
-mysql-connector-java-version=5.1.25
 hive-artifact=org.apache.hive:hive-exec:1.1.1

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/resources/META-INF/asakusa-legacy-gradle/defaults.properties
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/resources/META-INF/asakusa-legacy-gradle/defaults.properties
@@ -1,0 +1,8 @@
+
+## ThunderGate assembly
+commons-configuration-version=1.10
+commons-io-version=2.4
+commons-lang-version=2.6
+commons-logging-version=1.2
+log4j-version=1.2.17
+mysql-connector-java-version=5.1.25

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/test/groovy/com/asakusafw/legacy/gradle/plugins/internal/AsakusaLegacyOrganizerPluginTest.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/test/groovy/com/asakusafw/legacy/gradle/plugins/internal/AsakusaLegacyOrganizerPluginTest.groovy
@@ -54,6 +54,7 @@ class AsakusaLegacyOrganizerPluginTest extends OrganizerTestRoot {
     public void parents() {
         assert !project.plugins.hasPlugin(AsakusaSdkPlugin)
         assert project.plugins.hasPlugin(AsakusafwOrganizerPlugin)
+        assert project.plugins.hasPlugin(AsakusaLegacyBasePlugin)
     }
 
     /**

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/test/groovy/com/asakusafw/thundergate/gradle/plugins/internal/AsakusaThunderGateOrganizerPluginTest.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/test/groovy/com/asakusafw/thundergate/gradle/plugins/internal/AsakusaThunderGateOrganizerPluginTest.groovy
@@ -27,6 +27,7 @@ import com.asakusafw.gradle.plugins.AsakusafwOrganizerPlugin
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerProfile
 import com.asakusafw.gradle.plugins.OrganizerTestRoot
 import com.asakusafw.gradle.plugins.internal.AsakusaSdkPlugin
+import com.asakusafw.legacy.gradle.plugins.internal.AsakusaLegacyBasePlugin
 import com.asakusafw.thundergate.gradle.plugins.AsakusafwOrganizerThunderGateExtension
 
 /**
@@ -55,6 +56,7 @@ class AsakusaThunderGateOrganizerPluginTest extends OrganizerTestRoot {
     public void parents() {
         assert !project.plugins.hasPlugin(AsakusaSdkPlugin)
         assert project.plugins.hasPlugin(AsakusafwOrganizerPlugin)
+        assert project.plugins.hasPlugin(AsakusaLegacyBasePlugin)
     }
 
     /**

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/test/groovy/com/asakusafw/thundergate/gradle/plugins/internal/AsakusaThunderGateSdkPluginTest.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/test/groovy/com/asakusafw/thundergate/gradle/plugins/internal/AsakusaThunderGateSdkPluginTest.groovy
@@ -29,6 +29,7 @@ import com.asakusafw.gradle.plugins.AsakusafwPluginConvention
 import com.asakusafw.gradle.plugins.internal.AsakusaSdk
 import com.asakusafw.gradle.plugins.internal.AsakusaSdkPlugin
 import com.asakusafw.gradle.tasks.GenerateThunderGateDataModelTask
+import com.asakusafw.legacy.gradle.plugins.internal.AsakusaLegacyBasePlugin
 import com.asakusafw.thundergate.gradle.plugins.AsakusafwSdkThunderGateExtension
 
 /**
@@ -59,6 +60,7 @@ class AsakusaThunderGateSdkPluginTest {
     public void parents() {
         assert project.plugins.hasPlugin(AsakusaSdkPlugin)
         assert !project.plugins.hasPlugin(AsakusafwOrganizerPlugin)
+        assert project.plugins.hasPlugin(AsakusaLegacyBasePlugin)
     }
 
     /**

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,6 @@
     <plugin.javadoc.version>2.10.3</plugin.javadoc.version>
 
     <!-- artifact versions -->
-    <asakusafw.groupId>com.asakusafw</asakusafw.groupId>
     <asakusafw.version>0.8.1-SNAPSHOT</asakusafw.version>
     <asakusafw-legacy.version>0.8.1-SNAPSHOT</asakusafw-legacy.version>
     <hadoop.version>2.7.2</hadoop.version>
@@ -334,7 +333,7 @@ encoding/<project>=UTF-8
           <version>2.11</version>
           <dependencies>
             <dependency>
-              <groupId>${asakusafw.groupId}</groupId>
+              <groupId>com.asakusafw</groupId>
               <artifactId>build-tools</artifactId>
               <version>${asakusafw.version}</version>
             </dependency>
@@ -390,7 +389,7 @@ encoding/<project>=UTF-8
           <version>3.0.0</version>
           <dependencies>
             <dependency>
-              <groupId>${asakusafw.groupId}</groupId>
+              <groupId>com.asakusafw</groupId>
               <artifactId>build-tools</artifactId>
               <version>${asakusafw.version}</version>
             </dependency>
@@ -398,7 +397,6 @@ encoding/<project>=UTF-8
           <configuration>
             <xmlOutput>true</xmlOutput>
             <findbugsXmlOutput>true</findbugsXmlOutput>
-            <excludeFilterFile>com/asakusafw/fb_exclude.xml</excludeFilterFile>
             <sourceEncoding>UTF-8</sourceEncoding>
             <outputEncoding>UTF-8</outputEncoding>
           </configuration>
@@ -414,7 +412,7 @@ encoding/<project>=UTF-8
               <version>${checkstyle.version}</version>
             </dependency>
             <dependency>
-              <groupId>${asakusafw.groupId}</groupId>
+              <groupId>com.asakusafw</groupId>
               <artifactId>build-tools</artifactId>
               <version>${asakusafw.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -47,6 +47,7 @@
     <!-- artifact versions -->
     <asakusafw.groupId>com.asakusafw</asakusafw.groupId>
     <asakusafw.version>0.8.1-SNAPSHOT</asakusafw.version>
+    <asakusafw-legacy.version>0.8.1-SNAPSHOT</asakusafw-legacy.version>
     <hadoop.version>2.7.2</hadoop.version>
     <commons-cli.version>1.2</commons-cli.version>
     <slf4j.version>1.7.10</slf4j.version>


### PR DESCRIPTION
## Summary

This commit separates framework versions into core and legacy modules in Gradle plug-ins. 

## Background, Problem or Goal of the patch

Each `asakuasfw` and `asakusafw-legacy` has the separated version but Asakusa Gradle plug-ins assumes they have the same version.

## Design of the fix, or a new feature

This commit introduces the two following files:
* `META-INF/asakusa-legacy-gradle/artifact.properties`
* `META-INF/asakusa-legacy-gradle/defaults.properties`

The above are like as `META-INF/asakusa-gradle/*.properties`, but they are only for legacy modules in `asakusafw-legacy`.

Additionally, we removed some artifact versions which are referred only from the legacy modules.

## Related Issue, Pull Request or Code

* #95

## Wanted reviewer

@akirakw 