### PR TITLE
Fix Main-Class attribute of asakusa-tool-launcher.

### DIFF
--- a/asakusa-tool-launcher/pom.xml
+++ b/asakusa-tool-launcher/pom.xml
@@ -26,7 +26,7 @@
               <transformers>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
-                  <mainClass>com.asakusafw.lang.tool.launcher.Launcher</mainClass>
+                  <mainClass>com.asakusafw.sdk.launcher.Launcher</mainClass>
                 </transformer>
               </transformers>
               <shadedArtifactAttached>true</shadedArtifactAttached>


### PR DESCRIPTION
## Summary

This PR fixes JAR manifest `Main-Class` attribute of `asakusa-tool-launcher`. 

## Background, Problem or Goal of the patch

The implementation has been referred wrong main class name in `asakusa-tool-launcher:exec`.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

N/A.
