### PR TITLE
Bump up Java version to 1.8.

### DIFF
--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwPluginConvention.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwPluginConvention.groovy
@@ -175,7 +175,7 @@ class AsakusafwPluginConvention {
          * Java version compatibility to use when compiling Java source.
          * <dl>
          *   <dt> Default value: </dt>
-         *     <dd> {@code '1.7'} </dd>
+         *     <dd> {@code '1.8'} </dd>
          * </dl>
          */
         JavaVersion sourceCompatibility
@@ -184,7 +184,7 @@ class AsakusafwPluginConvention {
          * Java version to generate classes for.
          * <dl>
          *   <dt> Default value: </dt>
-         *     <dd> {@code '1.7'} </dd>
+         *     <dd> {@code '1.8'} </dd>
          * </dl>
          */
         JavaVersion targetCompatibility

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/main/resources/META-INF/asakusa-gradle/defaults.properties
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/main/resources/META-INF/asakusa-gradle/defaults.properties
@@ -1,5 +1,5 @@
 ## project configurations
-java-version=1.7
+java-version=1.8
 gradle-version=2.14.1
 embedded-libs-directory=src/main/libs
 

--- a/gradle-sdk-project/asakusa-gradle-plugins/src/test/groovy/com/asakusafw/gradle/plugins/AsakusafwPluginConventionTest.groovy
+++ b/gradle-sdk-project/asakusa-gradle-plugins/src/test/groovy/com/asakusafw/gradle/plugins/AsakusafwPluginConventionTest.groovy
@@ -109,8 +109,8 @@ class AsakusafwPluginConventionTest {
     void javac_defaults() {
         assert convention.javac.annotationSourceDirectory == "${project.buildDir}/generated-sources/annotations"
         assert convention.javac.sourceEncoding == "UTF-8"
-        assert convention.javac.sourceCompatibility == JavaVersion.VERSION_1_7
-        assert convention.javac.targetCompatibility == JavaVersion.VERSION_1_7
+        assert convention.javac.sourceCompatibility == JavaVersion.VERSION_1_8
+        assert convention.javac.targetCompatibility == JavaVersion.VERSION_1_8
     }
 
     /**
@@ -122,7 +122,7 @@ class AsakusafwPluginConventionTest {
         assert convention.compiler.compiledSourcePackage == "${project.asakusafw.basePackage}.batchapp"
         assert convention.compiler.compiledSourceDirectory == "${project.buildDir}/batchc"
         assert convention.compiler.compilerOptions == [
-                String.format("XjavaVersion=%s", JavaVersion.VERSION_1_7.toString())]
+                String.format("XjavaVersion=%s", JavaVersion.VERSION_1_8.toString())]
         assert convention.compiler.compilerWorkDirectory == null
         assert convention.compiler.hadoopWorkDirectory == 'target/hadoopwork/${execution_id}'
     }

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
 
     <!-- Build settings -->
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <java.version>1.8</java.version>
     <artifact.name>${project.artifactId}</artifact.name>
     <artifact.version>${project.version}</artifact.version>
     <artifact.id>${artifact.name}-${artifact.version}</artifact.id>
@@ -213,8 +214,8 @@
           <configuration>
             <fork>true</fork>
             <encoding>UTF-8</encoding>
-            <source>1.7</source>
-            <target>1.7</target>
+            <source>${java.version}</source>
+            <target>${java.version}</target>
             <proc>none</proc>
           </configuration>
         </plugin>
@@ -282,7 +283,7 @@
             <downloadSources>true</downloadSources>
             <downloadJavadocs>false</downloadJavadocs>
             <classpathContainers>
-              <classpathContainer>org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-1.7</classpathContainer>
+              <classpathContainer>org.eclipse.jdt.launching.JRE_CONTAINER/org.eclipse.jdt.internal.debug.ui.launcher.StandardVMType/JavaSE-${java.version}</classpathContainer>
             </classpathContainers>
             <additionalConfig>
               <file>


### PR DESCRIPTION
## Summary

This PR bumps up application Java version to `1.8`.

## Background, Problem or Goal of the patch

N/A.

## Design of the fix, or a new feature

Note that the Java version of building Gradle plugin is still `1.7`.
This is for backward compatibility of `asakusaUpgrade` task.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 