### PR TITLE
Fix for asakusafw/asakusafw#663.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBaseExtension.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBaseExtension.groovy
@@ -19,7 +19,7 @@ package com.asakusafw.gradle.plugins
  * An extension object for the Asakusa features.
  * This is only for internal use.
  * @since 0.8.0
- * @version 0.8.1
+ * @version 0.9.0
  */
 class AsakusafwBaseExtension {
 
@@ -102,4 +102,9 @@ class AsakusafwBaseExtension {
      * The default Hive artifact notation.
      */
     String hiveArtifact
+
+    /**
+     * Whether or not new Operator DSL compiler is enabled.
+     */
+    boolean enableNewOperatorCompiler
 }

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/EclipsePluginEnhancement.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/EclipsePluginEnhancement.groovy
@@ -55,19 +55,7 @@ class EclipsePluginEnhancement {
             AsakusafwBaseExtension base = AsakusafwBasePlugin.get(project)
             AsakusafwPluginConvention sdk =  project.asakusafw
             project.dependencies {
-                eclipseAnnotationProcessor "com.asakusafw:asakusa-runtime:${sdk.asakusafwVersion}"
-                eclipseAnnotationProcessor "com.asakusafw:asakusa-dsl-vocabulary:${sdk.asakusafwVersion}"
-                eclipseAnnotationProcessor "com.asakusafw:ashigel-compiler:${sdk.asakusafwVersion}"
-                eclipseAnnotationProcessor "com.asakusafw:java-dom:${sdk.asakusafwVersion}"
-                eclipseAnnotationProcessor "com.asakusafw:javadoc-parser:${sdk.asakusafwVersion}"
-                eclipseAnnotationProcessor "com.asakusafw:jsr269-bridge:${sdk.asakusafwVersion}"
-                eclipseAnnotationProcessor "com.asakusafw:collections:${sdk.asakusafwVersion}"
-                eclipseAnnotationProcessor "com.asakusafw:simple-graph:${sdk.asakusafwVersion}"
-                eclipseAnnotationProcessor "commons-io:commons-io:${base.commonsIoVersion}"
-                eclipseAnnotationProcessor "commons-lang:commons-lang:${base.commonsLangVersion}"
-                eclipseAnnotationProcessor "ch.qos.logback:logback-classic:${base.logbackVersion}"
-                eclipseAnnotationProcessor "ch.qos.logback:logback-core:${base.logbackVersion}"
-                eclipseAnnotationProcessor "org.slf4j:slf4j-api:${base.slf4jVersion}"
+                eclipseAnnotationProcessor "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-operator:${sdk.asakusafwVersion}:lib@jar"
             }
         }
     }

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/EclipsePluginEnhancement.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/EclipsePluginEnhancement.groovy
@@ -55,7 +55,11 @@ class EclipsePluginEnhancement {
             AsakusafwBaseExtension base = AsakusafwBasePlugin.get(project)
             AsakusafwPluginConvention sdk =  project.asakusafw
             project.dependencies {
-                eclipseAnnotationProcessor "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-operator:${sdk.asakusafwVersion}:lib@jar"
+                if (base.enableNewOperatorCompiler) {
+                    eclipseAnnotationProcessor "com.asakusafw.operator:asakusa-operator-all:${sdk.asakusafwVersion}:lib@jar"
+                } else {
+                    eclipseAnnotationProcessor "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-operator:${sdk.asakusafwVersion}:lib@jar"
+                }
             }
         }
     }

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
@@ -161,8 +161,15 @@ class AsakusaSdkPlugin implements Plugin<Project> {
             AsakusafwBaseExtension base = AsakusafwBasePlugin.get(project)
             project.dependencies {
                 embedded project.sourceSets.main.libs
+
                 compile group: 'org.slf4j', name: 'jcl-over-slf4j', version: base.slf4jVersion
                 compile group: 'ch.qos.logback', name: 'logback-classic', version: base.logbackVersion
+                if (base.enableNewOperatorCompiler) {
+                    compile "com.asakusafw.operator:asakusa-operator-all:${extension.asakusafwVersion}"
+                } else {
+                    compile "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-operator:${extension.asakusafwVersion}"
+                }
+
                 asakusaHiveCli group: 'com.asakusafw', name: 'asakusa-hive-cli', version: extension.asakusafwVersion
 
                 // TODO: remove this feature

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusafwOrganizer.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusafwOrganizer.groovy
@@ -135,7 +135,7 @@ class AsakusafwOrganizer extends AbstractOrganizer {
                 YaessIterativeLib : [
                     "com.asakusafw:asakusa-iterative-yaess:${frameworkVersion}:lib@jar",
                 ],
-                WindGateDist : "com.asakusafw:asakusa-windgate-plugin:${frameworkVersion}:dist@jar",
+                WindGateDist : "com.asakusafw:asakusa-windgate-bootstrap:${frameworkVersion}:dist@jar",
                 WindGateLib : [
                     "com.asakusafw:asakusa-windgate-bootstrap:${frameworkVersion}@jar",
                     "com.asakusafw:asakusa-windgate-core:${frameworkVersion}@jar",

--- a/gradle/src/test/groovy/com/asakusafw/gradle/plugins/GradleTestkitHelper.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/gradle/plugins/GradleTestkitHelper.groovy
@@ -45,7 +45,7 @@ final class GradleTestkitHelper {
         lines << '  }'
         lines << '  dependencies {'
         if (!classpath.empty) {
-            lines << "    classpath files(${classpath.collect { "'''${it.absolutePath}'''" }.join(', ')})"
+            lines << "    classpath files(${classpath.collect { "'''${it.absolutePath.replace('\\', '/')}'''" }.join(', ')})"
         }
         lines << "    classpath 'org.codehaus.groovy:groovy-backports-compat23:${GroovySystem.version}'"
         lines << '  }'


### PR DESCRIPTION
## Summary

This PR fixes for upstream changes in asakusafw/asakusafw#663.

## Background, Problem or Goal of the patch

The upstream changes have impacts for this repository:
* renamed artifact of operator DSL compiler
* renamed artifact of WindGate assemblies

## Design of the fix, or a new feature

This PR also enables to switch the old/new operator DSL compiler (the old one is still activated in default). To use the new one, please insert the follow statement into your `build.gradle`:

```groovy
asakusafwBase.enableNewOperatorCompiler true
```

## Related Issue, Pull Request or Code

* asakusafw/asakusafw#663

## Wanted reviewer

@akirakw