### PR TITLE
Change default value of asakusafw.sdk.windgate

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
@@ -122,7 +122,7 @@ class AsakusaSdkPlugin implements Plugin<Project> {
             testing true
             testkit true
             directio true
-            windgate false
+            windgate true
             hive false
         }
         extension.dmdl.conventionMapping.with {


### PR DESCRIPTION
## Summary
This PR changes default configuration of enabling `windgate` on `asakusafw.sdk` from disable to enable (follow-up #109) .

## Background, Problem or Goal of the patch
This change is for considering migration from conventional project.

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
#109 

## Wanted reviewer
N/A.
