### PR TITLE
Make `*.asakusafwVersion` unmodifiable.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPlugin.groovy
@@ -85,11 +85,10 @@ class AsakusafwOrganizerPlugin  implements Plugin<Project> {
 
         convention.conventionMapping.with {
             asakusafwVersion = {
-                if (project.plugins.hasPlugin('asakusafw-sdk')) {
-                    return project.asakusafw.asakusafwVersion
-                } else {
-                    throw new InvalidUserDataException('"asakusafwOrganizer.asakusafwVersion" must be set')
+                if (base.frameworkVersion == null) {
+                    throw new InvalidUserDataException('Asakusa Framework core libraries version is not defined')
                 }
+                return base.frameworkVersion
             }
             assembleDir = { (String) "${project.buildDir}/asakusafw-assembly" }
         }
@@ -128,6 +127,7 @@ class AsakusafwOrganizerPlugin  implements Plugin<Project> {
         }
         convention.profiles.create(PROFILE_NAME_PRODUCTION) { AsakusafwOrganizerProfile profile ->
             profile.conventionMapping.with {
+                // FIXME default archive name
                 archiveName = { (String) "asakusafw-${profile.asakusafwVersion}.tar.gz" }
             }
         }
@@ -167,8 +167,9 @@ class AsakusafwOrganizerPlugin  implements Plugin<Project> {
         profile.extension = profile.extensions.create('extension', ExtensionConfiguration)
 
         profile.conventionMapping.with {
-            asakusafwVersion = { convention.asakusafwVersion }
+            asakusafwVersion = { convention.asakusafwVersion } // ok, this just inherits parent version
             assembleDir = { (String) "${convention.assembleDir}-${profile.name}" }
+            // FIXME default archive name
             archiveName = { (String) "asakusafw-${profile.asakusafwVersion}-${profile.name}.tar.gz" }
         }
         profile.components.process {

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPlugin.groovy
@@ -21,6 +21,7 @@ import org.gradle.api.tasks.bundling.*
 import org.gradle.util.ConfigureUtil
 
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention.BatchappsConfiguration
+import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention.CoreConfiguration
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention.DirectIoConfiguration
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention.ExtensionConfiguration
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention.HiveConfiguration
@@ -75,6 +76,7 @@ class AsakusafwOrganizerPlugin  implements Plugin<Project> {
     private void configureExtentionProperties() {
         AsakusafwBaseExtension base = AsakusafwBasePlugin.get(project)
         AsakusafwOrganizerPluginConvention convention = project.extensions.create('asakusafwOrganizer', AsakusafwOrganizerPluginConvention)
+        convention.core = convention.extensions.create('core', CoreConfiguration)
         convention.directio = convention.extensions.create('directio', DirectIoConfiguration)
         convention.windgate = convention.extensions.create('windgate', WindGateConfiguration)
         convention.hive = convention.extensions.create('hive', HiveConfiguration)
@@ -131,9 +133,9 @@ class AsakusafwOrganizerPlugin  implements Plugin<Project> {
                 archiveName = { (String) "asakusafw-${profile.asakusafwVersion}.tar.gz" }
             }
         }
-
-        convention.metaClass.toStringDelegate = { -> "asakusafwOrganizer { ... }" }
         PluginUtils.deprecateAsakusafwVersion project, 'asakusafwOrganizer', convention
+        PluginUtils.injectVersionProperty(convention.core, { base.frameworkVersion })
+        convention.metaClass.toStringDelegate = { -> "asakusafwOrganizer { ... }" }
     }
 
     private NamedDomainObjectContainer<AsakusafwOrganizerProfile> createProfileContainer(AsakusafwOrganizerPluginConvention convention) {
@@ -158,6 +160,8 @@ class AsakusafwOrganizerPlugin  implements Plugin<Project> {
     }
 
     private void configureProfile(AsakusafwOrganizerPluginConvention convention,  AsakusafwOrganizerProfile profile) {
+        AsakusafwBaseExtension base = AsakusafwBasePlugin.get(project)
+        profile.core = profile.extensions.create('core', CoreConfiguration)
         profile.directio = profile.extensions.create('directio', DirectIoConfiguration)
         profile.windgate = profile.extensions.create('windgate', WindGateConfiguration)
         profile.hive = profile.extensions.create('hive', HiveConfiguration)
@@ -207,6 +211,7 @@ class AsakusafwOrganizerPlugin  implements Plugin<Project> {
             defaultLibraries = { convention.extension.libraries }
         }
         PluginUtils.deprecateAsakusafwVersion project, "asakusafwOrganizer.profiles.${profile.name}", profile
+        PluginUtils.injectVersionProperty(profile.core, { base.frameworkVersion })
     }
 
     private void configureProfiles() {

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPluginConvention.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPluginConvention.groovy
@@ -47,6 +47,12 @@ class AsakusafwOrganizerPluginConvention {
     String assembleDir
 
     /**
+     * Core settings.
+     * @since 0.9.0
+     */
+    CoreConfiguration core
+
+    /**
      * Direct I/O settings.
      * @since 0.7.0
      */
@@ -98,6 +104,14 @@ class AsakusafwOrganizerPluginConvention {
      * Custom framework files.
      */
     final AsakusafwAssembly assembly = new AsakusafwAssembly("assembly")
+
+    /**
+     * Asakusa Framework organizer core settings.
+     * @since 0.9.0
+     */
+    static class CoreConfiguration {
+        // no special members
+    }
 
     /**
      * Direct I/O settings for the Asakusa Framework organizer.

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPluginConvention.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPluginConvention.groovy
@@ -22,18 +22,19 @@ import com.asakusafw.gradle.assembly.AsakusafwAssembly
 /**
  * Convention class for {@link AsakusafwOrganizerPlugin}.
  * @since 0.5.2
- * @version 0.8.0
+ * @version 0.9.0
  */
 class AsakusafwOrganizerPluginConvention {
 
     /**
-     * Asakusa Framework version.
+     * Asakusa Framework version (read only).
      * <dl>
      *   <dt> Default value: </dt>
-     *     <dd> {@code project.asakusafw.asakusafwVersion} - only if {@code asakusafw-sdk} plug-in is enabled </dd>
-     *     <dd> N/A - otherwise</dd>
+     *     <dd> Asakusa Framework Core libraries version </dd>
      * </dl>
+     * @deprecated use {@code asakusafwOrganizer.core.version} instead
      */
+    @Deprecated
     String asakusafwVersion
 
     /**

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerProfile.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerProfile.groovy
@@ -17,6 +17,7 @@ package com.asakusafw.gradle.plugins
 
 import com.asakusafw.gradle.assembly.AsakusafwAssembly
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention.BatchappsConfiguration
+import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention.CoreConfiguration
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention.DirectIoConfiguration
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention.ExtensionConfiguration
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention.HiveConfiguration
@@ -27,7 +28,7 @@ import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention.YaessConf
 /**
  * Represents an Asakusa Framework organization profile.
  * @since 0.7.0
- * @version 0.8.0
+ * @version 0.9.0
  */
 class AsakusafwOrganizerProfile {
 
@@ -66,6 +67,12 @@ class AsakusafwOrganizerProfile {
      * </dl>
      */
     String archiveName
+
+    /**
+     * Core settings.
+     * @since 0.9.0
+     */
+    CoreConfiguration core
 
     /**
      * Direct I/O settings.

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerProfile.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerProfile.groovy
@@ -37,12 +37,14 @@ class AsakusafwOrganizerProfile {
     final String name
 
     /**
-     * Asakusa Framework Version.
+     * Asakusa Framework Version (read only).
      * <dl>
      *   <dt> Default value: </dt>
      *     <dd> {@code project.asakusafwOrganizer.asakusafwVersion} </dd>
      * </dl>
+     * @deprecated use {@code asakusafwOrganizer.core.version} instead
      */
+    @Deprecated
     String asakusafwVersion
 
     /**
@@ -58,6 +60,7 @@ class AsakusafwOrganizerProfile {
      * The final archive name (should be end with {@code .tar.gz}).
      * <dl>
      *   <dt> Default value: </dt>
+     *     <!-- FIXME: default archive name -->
      *     <dd> <code>"asakusafw-${asakusafwVersion}-${name}.tar.gz"</code> - except 'prod' profile </dd>
      *     <dd> <code>"asakusafw-${asakusafwVersion}.tar.gz"</code> - for 'prod' profile </dd>
      * </dl>

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwPluginConvention.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwPluginConvention.groovy
@@ -43,9 +43,11 @@ class AsakusafwPluginConvention {
      * This property must be specified in project configuration.
      * <dl>
      *   <dt> Default value: </dt>
-     *     <dd> (same as the Asakusa Gradle plug-ins version) </dd>
+     *     <dd> Asakusa Framework Core libraries version </dd>
      * </dl>
+     * @deprecated use {@code asakusafw.core.version} instead
      */
+    @Deprecated
     String asakusafwVersion
 
     /**

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/EclipsePluginEnhancement.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/EclipsePluginEnhancement.groovy
@@ -52,13 +52,13 @@ class EclipsePluginEnhancement {
 
     private void configureDependencies() {
         PluginUtils.afterEvaluate(project) {
-            AsakusafwPluginConvention sdk =  project.asakusafw
+            AsakusafwBaseExtension base = AsakusafwBasePlugin.get(project)
             if (sdk.sdk.operator) {
                 project.dependencies {
                     if (sdk.sdk.operator == 'NEW') {
-                        eclipseAnnotationProcessor "com.asakusafw.operator:asakusa-operator-all:${sdk.asakusafwVersion}:lib@jar"
+                        eclipseAnnotationProcessor "com.asakusafw.operator:asakusa-operator-all:${base.frameworkVersion}:lib@jar"
                     } else {
-                        eclipseAnnotationProcessor "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-operator:${sdk.asakusafwVersion}:lib@jar"
+                        eclipseAnnotationProcessor "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-operator:${base.frameworkVersion}:lib@jar"
                     }
                 }
             }

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/EclipsePluginEnhancement.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/EclipsePluginEnhancement.groovy
@@ -53,6 +53,7 @@ class EclipsePluginEnhancement {
     private void configureDependencies() {
         PluginUtils.afterEvaluate(project) {
             AsakusafwBaseExtension base = AsakusafwBasePlugin.get(project)
+            AsakusafwPluginConvention sdk =  project.asakusafw
             if (sdk.sdk.operator) {
                 project.dependencies {
                     if (sdk.sdk.operator == 'NEW') {

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
@@ -154,7 +154,6 @@ class AsakusaSdkPlugin implements Plugin<Project> {
             testDataSheetDirectory = { (String) "${project.buildDir}/excel" }
         }
         PluginUtils.deprecateAsakusafwVersion project, 'asakusafw', extension
-
         PluginUtils.injectVersionProperty(extension.core, { base.frameworkVersion })
         extension.metaClass.toStringDelegate = { -> "asakusafw { ... }" }
     }

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
@@ -102,7 +102,7 @@ class AsakusaSdkPlugin implements Plugin<Project> {
         extension.conventionMapping.with {
             asakusafwVersion = {
                 if (base.frameworkVersion == null) {
-                    throw new InvalidUserDataException('"asakusafw.asakusafwVersion" must be set')
+                    throw new InvalidUserDataException('Asakusa Framework core libraries version is not defined')
                 }
                 return base.frameworkVersion
             }
@@ -183,7 +183,7 @@ class AsakusaSdkPlugin implements Plugin<Project> {
 
                 compile group: 'org.slf4j', name: 'jcl-over-slf4j', version: base.slf4jVersion
                 compile group: 'ch.qos.logback', name: 'logback-classic', version: base.logbackVersion
-                asakusaHiveCli group: 'com.asakusafw', name: 'asakusa-hive-cli', version: extension.asakusafwVersion
+                asakusaHiveCli group: 'com.asakusafw', name: 'asakusa-hive-cli', version: base.frameworkVersion
             }
         }
     }
@@ -191,51 +191,50 @@ class AsakusaSdkPlugin implements Plugin<Project> {
     private void configureClasspath() {
         PluginUtils.afterEvaluate(project) {
             AsakusafwBaseExtension base = AsakusafwBasePlugin.get(project)
-            String version = extension.asakusafwVersion
             AsakusafwSdkExtension features = extension.sdk
             project.dependencies {
                 if (features.core) {
-                    compile "com.asakusafw.sdk:asakusa-sdk-app-core:${version}"
+                    compile "com.asakusafw.sdk:asakusa-sdk-app-core:${base.frameworkVersion}"
                     if (features.operator) {
                         // FIXME temporary
                         if (features.operator == 'NEW') {
-                            compile "com.asakusafw.operator:asakusa-operator-all:${extension.asakusafwVersion}"
+                            compile "com.asakusafw.operator:asakusa-operator-all:${base.frameworkVersion}"
                         } else {
-                            compile "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-operator:${extension.asakusafwVersion}"
+                            compile "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-operator:${base.frameworkVersion}"
                         }
                     }
                     if (features.directio) {
-                        compile "com.asakusafw.sdk:asakusa-sdk-app-directio:${version}"
+                        compile "com.asakusafw.sdk:asakusa-sdk-app-directio:${base.frameworkVersion}"
                     }
                     if (features.windgate) {
-                        compile "com.asakusafw.sdk:asakusa-sdk-app-windgate:${version}"
+                        compile "com.asakusafw.sdk:asakusa-sdk-app-windgate:${base.frameworkVersion}"
                     }
                     if (features.hive) {
-                        compile "com.asakusafw.sdk:asakusa-sdk-app-hive:${version}"
+                        compile "com.asakusafw.sdk:asakusa-sdk-app-hive:${base.frameworkVersion}"
                     }
                 }
                 if (features.testing) {
-                    testCompile "com.asakusafw.sdk:asakusa-sdk-test-core:${version}"
+                    testCompile "com.asakusafw.sdk:asakusa-sdk-test-core:${base.frameworkVersion}"
                     if (features.directio) {
-                        testCompile "com.asakusafw.sdk:asakusa-sdk-test-directio:${version}"
+                        testCompile "com.asakusafw.sdk:asakusa-sdk-test-directio:${base.frameworkVersion}"
                     }
                     if (features.windgate) {
-                        testCompile "com.asakusafw.sdk:asakusa-sdk-test-windgate:${version}"
+                        testCompile "com.asakusafw.sdk:asakusa-sdk-test-windgate:${base.frameworkVersion}"
                     }
                     if (features.testkit) {
                         AsakusaTestkit found = findTestkit(features.testkit, features.availableTestkits)?.apply(project)
                     }
                 }
                 if (features.dmdl) {
-                    asakusaDmdlCompiler "com.asakusafw.sdk:asakusa-sdk-dmdl-core:${version}"
+                    asakusaDmdlCompiler "com.asakusafw.sdk:asakusa-sdk-dmdl-core:${base.frameworkVersion}"
                     if (features.directio) {
-                        asakusaDmdlCompiler "com.asakusafw.sdk:asakusa-sdk-dmdl-directio:${version}"
+                        asakusaDmdlCompiler "com.asakusafw.sdk:asakusa-sdk-dmdl-directio:${base.frameworkVersion}"
                     }
                     if (features.windgate) {
-                        asakusaDmdlCompiler "com.asakusafw.sdk:asakusa-sdk-dmdl-windgate:${version}"
+                        asakusaDmdlCompiler "com.asakusafw.sdk:asakusa-sdk-dmdl-windgate:${base.frameworkVersion}"
                     }
                     if (features.hive) {
-                        asakusaDmdlCompiler "com.asakusafw.sdk:asakusa-sdk-dmdl-hive:${version}"
+                        asakusaDmdlCompiler "com.asakusafw.sdk:asakusa-sdk-dmdl-hive:${base.frameworkVersion}"
                     }
                 }
             }
@@ -377,13 +376,8 @@ class AsakusaSdkPlugin implements Plugin<Project> {
 
     private void extendVersionsTask() {
         project.tasks.getByName(AsakusafwBasePlugin.TASK_VERSIONS) << {
-            def frameworkVersion
-            try {
-                frameworkVersion = extension.asakusafwVersion
-            } catch (Exception e) {
-                frameworkVersion = 'INVALID'
-            }
-            logger.lifecycle "Asakusa SDK: ${frameworkVersion}"
+            AsakusafwBaseExtension base = AsakusafwBasePlugin.get(project)
+            logger.lifecycle "Asakusa SDK: ${base.frameworkVersion ?: 'INVALID'}"
             logger.lifecycle "JVM: ${extension.javac.targetCompatibility}"
         }
     }

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusafwOrganizer.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusafwOrganizer.groovy
@@ -89,21 +89,20 @@ class AsakusafwOrganizer extends AbstractOrganizer {
 
     private void configureDependencies() {
         PluginUtils.afterEvaluate(project) {
-            String frameworkVersion = profile.asakusafwVersion
             AsakusafwBaseExtension base = AsakusafwBasePlugin.get(project)
             createDependencies('asakusafw', [
-                CoreDist : "com.asakusafw:asakusa-runtime-configuration:${frameworkVersion}:dist@jar",
+                CoreDist : "com.asakusafw:asakusa-runtime-configuration:${base.frameworkVersion}:dist@jar",
                 CoreLib : [
-                    "com.asakusafw:asakusa-runtime-all:${frameworkVersion}:lib@jar"
+                    "com.asakusafw:asakusa-runtime-all:${base.frameworkVersion}:lib@jar"
                 ],
-                DirectIoDist : "com.asakusafw:asakusa-directio-tools:${frameworkVersion}:dist@jar",
+                DirectIoDist : "com.asakusafw:asakusa-directio-tools:${base.frameworkVersion}:dist@jar",
                 DirectIoLib : [
-                    "com.asakusafw:asakusa-directio-tools:${frameworkVersion}@jar"
+                    "com.asakusafw:asakusa-directio-tools:${base.frameworkVersion}@jar"
                 ],
-                YaessDist : "com.asakusafw:asakusa-yaess-bootstrap:${frameworkVersion}:dist@jar",
+                YaessDist : "com.asakusafw:asakusa-yaess-bootstrap:${base.frameworkVersion}:dist@jar",
                 YaessLib : [
-                    "com.asakusafw:asakusa-yaess-bootstrap:${frameworkVersion}@jar",
-                    "com.asakusafw:asakusa-yaess-core:${frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-yaess-bootstrap:${base.frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-yaess-core:${base.frameworkVersion}@jar",
                     "commons-cli:commons-cli:${base.commonsCliVersion}@jar",
                     "ch.qos.logback:logback-classic:${base.logbackVersion}@jar",
                     "ch.qos.logback:logback-core:${base.logbackVersion}@jar",
@@ -111,21 +110,21 @@ class AsakusafwOrganizer extends AbstractOrganizer {
                     "org.slf4j:jul-to-slf4j:${base.slf4jVersion}@jar",
                 ],
                 YaessPlugin : [
-                    "com.asakusafw:asakusa-yaess-flowlog:${frameworkVersion}@jar",
-                    "com.asakusafw:asakusa-yaess-jsch:${frameworkVersion}@jar",
-                    "com.asakusafw:asakusa-yaess-multidispatch:${frameworkVersion}@jar",
-                    "com.asakusafw:asakusa-yaess-paralleljob:${frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-yaess-flowlog:${base.frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-yaess-jsch:${base.frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-yaess-multidispatch:${base.frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-yaess-paralleljob:${base.frameworkVersion}@jar",
                     "com.jcraft:jsch:${base.jschVersion}@jar",
                 ],
-                YaessHadoopDist : "com.asakusafw:asakusa-yaess-core:${frameworkVersion}:dist@jar",
+                YaessHadoopDist : "com.asakusafw:asakusa-yaess-core:${base.frameworkVersion}:dist@jar",
                 YaessHadoopLib : [],
-                YaessToolsDist : "com.asakusafw:asakusa-yaess-tools:${frameworkVersion}:dist@jar",
+                YaessToolsDist : "com.asakusafw:asakusa-yaess-tools:${base.frameworkVersion}:dist@jar",
                 YaessToolsLib : [
-                    "com.asakusafw:asakusa-yaess-tools:${frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-yaess-tools:${base.frameworkVersion}@jar",
                     "com.google.code.gson:gson:${base.gsonVersion}@jar",
                 ],
                 YaessJobQueueLib : [
-                    "com.asakusafw:asakusa-yaess-jobqueue:${frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-yaess-jobqueue:${base.frameworkVersion}@jar",
                     "org.apache.httpcomponents:httpcore:${base.httpClientVersion}@jar",
                     "org.apache.httpcomponents:httpclient:${base.httpClientVersion}@jar",
                     "com.google.code.gson:gson:${base.gsonVersion}@jar",
@@ -133,12 +132,12 @@ class AsakusafwOrganizer extends AbstractOrganizer {
                     "commons-logging:commons-logging:${base.commonsLoggingVersion}@jar",
                 ],
                 YaessIterativeLib : [
-                    "com.asakusafw:asakusa-iterative-yaess:${frameworkVersion}:lib@jar",
+                    "com.asakusafw:asakusa-iterative-yaess:${base.frameworkVersion}:lib@jar",
                 ],
-                WindGateDist : "com.asakusafw:asakusa-windgate-bootstrap:${frameworkVersion}:dist@jar",
+                WindGateDist : "com.asakusafw:asakusa-windgate-bootstrap:${base.frameworkVersion}:dist@jar",
                 WindGateLib : [
-                    "com.asakusafw:asakusa-windgate-bootstrap:${frameworkVersion}@jar",
-                    "com.asakusafw:asakusa-windgate-core:${frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-windgate-bootstrap:${base.frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-windgate-core:${base.frameworkVersion}@jar",
                     "ch.qos.logback:logback-classic:${base.logbackVersion}@jar",
                     "ch.qos.logback:logback-core:${base.logbackVersion}@jar",
                     "org.slf4j:slf4j-api:${base.slf4jVersion}@jar",
@@ -146,14 +145,14 @@ class AsakusafwOrganizer extends AbstractOrganizer {
                     "com.jcraft:jsch:${base.jschVersion}@jar",
                 ],
                 WindGatePlugin : [
-                    "com.asakusafw:asakusa-windgate-hadoopfs:${frameworkVersion}@jar",
-                    "com.asakusafw:asakusa-windgate-jdbc:${frameworkVersion}@jar",
-                    "com.asakusafw:asakusa-windgate-stream:${frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-windgate-hadoopfs:${base.frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-windgate-jdbc:${base.frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-windgate-stream:${base.frameworkVersion}@jar",
                 ],
-                WindGateSshDist : "com.asakusafw:asakusa-windgate-hadoopfs:${frameworkVersion}:dist@jar",
+                WindGateSshDist : "com.asakusafw:asakusa-windgate-hadoopfs:${base.frameworkVersion}:dist@jar",
                 WindGateSshLib : [
-                    "com.asakusafw:asakusa-windgate-core:${frameworkVersion}@jar",
-                    "com.asakusafw:asakusa-windgate-hadoopfs:${frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-windgate-core:${base.frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-windgate-hadoopfs:${base.frameworkVersion}@jar",
                     "ch.qos.logback:logback-classic:${base.logbackVersion}@jar",
                     "ch.qos.logback:logback-core:${base.logbackVersion}@jar",
                     "org.slf4j:slf4j-api:${base.slf4jVersion}@jar",
@@ -161,12 +160,12 @@ class AsakusafwOrganizer extends AbstractOrganizer {
                 ],
                 WindGateRetryableDist : [],
                 WindGateRetryableLib : [
-                    "com.asakusafw:asakusa-windgate-retryable:${frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-windgate-retryable:${base.frameworkVersion}@jar",
                 ],
-                TestingDist : "com.asakusafw:asakusa-test-driver:${frameworkVersion}:dist@jar",
-                OperationDist : "com.asakusafw:asakusa-operation-tools:${frameworkVersion}:dist@jar",
+                TestingDist : "com.asakusafw:asakusa-test-driver:${base.frameworkVersion}:dist@jar",
+                OperationDist : "com.asakusafw:asakusa-operation-tools:${base.frameworkVersion}:dist@jar",
                 OperationLib : [
-                    "com.asakusafw:asakusa-operation-tools:${frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-operation-tools:${base.frameworkVersion}@jar",
                     "commons-cli:commons-cli:${base.commonsCliVersion}@jar",
                     "ch.qos.logback:logback-classic:${base.logbackVersion}@jar",
                     "ch.qos.logback:logback-core:${base.logbackVersion}@jar",
@@ -174,8 +173,8 @@ class AsakusafwOrganizer extends AbstractOrganizer {
                 ],
                 DirectIoHiveDist : [],
                 DirectIoHiveLib : [
-                    "com.asakusafw:asakusa-hive-info:${frameworkVersion}@jar",
-                    "com.asakusafw:asakusa-hive-core:${frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-hive-info:${base.frameworkVersion}@jar",
+                    "com.asakusafw:asakusa-hive-core:${base.frameworkVersion}@jar",
                 ] + profile.hive.libraries,
                 ExtensionLib : profile.extension.libraries,
             ])

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/PluginUtils.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/PluginUtils.groovy
@@ -123,15 +123,12 @@ final class PluginUtils {
         instance.metaClass.getAsakusafwVersion = { ->
             return getter()
         }
-        def setter = instance.&setAsakusafwVersion
         instance.metaClass.setAsakusafwVersion = { String arg ->
-            project.logger.warn "DEPRECATED: changing ${prefix}.asakusafwVersion is deprecated."
-            setter(arg)
+            project.logger.warn "DEPRECATED: changing ${prefix}.asakusafwVersion is ignored."
         }
         // asakusafwVersion(String) does not via Groovy MOP when calls setAsakusafwVersion()
         instance.metaClass.asakusafwVersion = { String arg ->
-            project.logger.warn "DEPRECATED: changing ${prefix}.asakusafwVersion is deprecated."
-            setter(arg)
+            project.logger.warn "DEPRECATED: changing ${prefix}.asakusafwVersion is ignored."
         }
         return instance
     }

--- a/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceOrganizerPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceOrganizerPlugin.groovy
@@ -23,6 +23,7 @@ import org.gradle.api.Task
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPlugin
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerPluginConvention
 import com.asakusafw.gradle.plugins.AsakusafwOrganizerProfile
+import com.asakusafw.gradle.plugins.internal.PluginUtils
 import com.asakusafw.mapreduce.gradle.plugins.AsakusafwOrganizerMapReduceExtension
 
 /**
@@ -39,7 +40,7 @@ class AsakusaMapReduceOrganizerPlugin implements Plugin<Project> {
         this.project = project
         this.organizers = project.container(AsakusaMapReduceOrganizer)
 
-        project.apply plugin: 'asakusafw-organizer'
+        project.apply plugin: AsakusafwOrganizerPlugin
         project.apply plugin: AsakusaMapReduceBasePlugin
 
         configureConvention()
@@ -56,11 +57,13 @@ class AsakusaMapReduceOrganizerPlugin implements Plugin<Project> {
     }
 
     private void configureConvention() {
+        AsakusaMapReduceBaseExtension base = AsakusaMapReduceBasePlugin.get(project)
         AsakusafwOrganizerPluginConvention convention = project.asakusafwOrganizer
         convention.extensions.create('mapreduce', AsakusafwOrganizerMapReduceExtension)
         convention.mapreduce.conventionMapping.with {
             enabled = { true }
         }
+        PluginUtils.injectVersionProperty(convention.mapreduce, { base.featureVersion })
     }
 
     private void configureProfiles() {
@@ -71,11 +74,13 @@ class AsakusaMapReduceOrganizerPlugin implements Plugin<Project> {
     }
 
     private void configureProfile(AsakusafwOrganizerProfile profile) {
-        AsakusafwOrganizerMapReduceExtension root =
+        AsakusaMapReduceBaseExtension base = AsakusaMapReduceBasePlugin.get(project)
         profile.extensions.create('mapreduce', AsakusafwOrganizerMapReduceExtension)
         profile.mapreduce.conventionMapping.with {
             enabled = { project.asakusafwOrganizer.mapreduce.enabled }
         }
+        PluginUtils.injectVersionProperty(profile.mapreduce, { base.featureVersion })
+
         AsakusaMapReduceOrganizer organizer = new AsakusaMapReduceOrganizer(project, profile)
         organizer.configureProfile()
         organizers << organizer

--- a/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkBasePlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkBasePlugin.groovy
@@ -85,26 +85,25 @@ class AsakusaMapReduceSdkBasePlugin implements Plugin<Project> {
         }
         PluginUtils.afterEvaluate(project) {
             AsakusaMapReduceBaseExtension base = AsakusaMapReduceBasePlugin.get(project)
-            AsakusafwPluginConvention sdk = AsakusaSdkPlugin.get(project)
-            AsakusafwSdkExtension features = sdk.sdk
+            AsakusafwSdkExtension features = AsakusaSdkPlugin.get(project).sdk
             project.dependencies {
                 if (features.core) {
-                    asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-core:${sdk.asakusafwVersion}"
-                    asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-inspection:${sdk.asakusafwVersion}"
-                    asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-yaess:${sdk.asakusafwVersion}"
-                    asakusaMapreduceCompiler "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-cli:${sdk.asakusafwVersion}"
+                    asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-core:${base.featureVersion}"
+                    asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-inspection:${base.featureVersion}"
+                    asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-yaess:${base.featureVersion}"
+                    asakusaMapreduceCompiler "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-cli:${base.featureVersion}"
                     if (features.directio) {
-                        asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-directio:${sdk.asakusafwVersion}"
+                        asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-directio:${base.featureVersion}"
                     }
                     if (features.windgate) {
-                        asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-windgate:${sdk.asakusafwVersion}"
+                        asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-windgate:${base.featureVersion}"
                     }
                     if (features.hive) {
-                        asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-hive:${sdk.asakusafwVersion}"
+                        asakusaMapreduceCommon "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-extension-hive:${base.featureVersion}"
                     }
                 }
                 if (features.testing) {
-                    asakusaMapreduceTestkit "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-test-adapter:${sdk.asakusafwVersion}"
+                    asakusaMapreduceTestkit "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-test-adapter:${base.featureVersion}"
                 }
             }
         }

--- a/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkBasePlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkBasePlugin.groovy
@@ -15,14 +15,9 @@
  */
 package com.asakusafw.mapreduce.gradle.plugins.internal
 
-import java.util.regex.Matcher
-import java.util.regex.Pattern
-
 import org.gradle.api.Plugin
 import org.gradle.api.Project
 
-import com.asakusafw.gradle.plugins.AsakusafwCompilerExtension
-import com.asakusafw.gradle.plugins.AsakusafwPluginConvention
 import com.asakusafw.gradle.plugins.AsakusafwSdkExtension
 import com.asakusafw.gradle.plugins.AsakusafwSdkPluginParticipant
 import com.asakusafw.gradle.plugins.internal.AsakusaSdkPlugin
@@ -30,16 +25,12 @@ import com.asakusafw.gradle.plugins.internal.PluginUtils
 
 /**
  * A base plug-in of {@link AsakusaMapReduceSdkPlugin}.
- * This only organizes conventions and dependencies.
+ * This only organizes dependencies and testkits.
  * @since 0.9.0
  */
 class AsakusaMapReduceSdkBasePlugin implements Plugin<Project> {
 
-    private static final Pattern OPTION_PATTERN = ~/([\+\-])\s*([0-9A-Za-z_\\-]+)|(X[0-9A-Za-z_\\-]+)=([^,]*)/
-
     private Project project
-
-    private AsakusafwCompilerExtension extension
 
     @Override
     void apply(Project project) {
@@ -47,24 +38,15 @@ class AsakusaMapReduceSdkBasePlugin implements Plugin<Project> {
 
         project.apply plugin: AsakusaSdkPlugin
         project.apply plugin: AsakusaMapReduceBasePlugin
-        this.extension = AsakusaSdkPlugin.get(project).extensions.create('mapreduce', AsakusafwCompilerExtension)
 
-        configureConvention()
+        configureTestkit()
         configureConfigurations()
     }
 
-    private void configureConvention() {
-        AsakusaMapReduceBaseExtension base = AsakusaMapReduceBasePlugin.get(project)
-        AsakusafwPluginConvention sdk = AsakusaSdkPlugin.get(project)
-        extension.conventionMapping.with {
-            outputDirectory = { project.file(sdk.compiler.compiledSourceDirectory) }
-            runtimeWorkingDirectory = { sdk.compiler.hadoopWorkDirectory }
-            compilerProperties = { parseOptions(sdk.compiler.compilerOptions) }
-            failOnError = { true }
-        }
-        PluginUtils.injectVersionProperty(extension, { base.featureVersion })
-        sdk.sdk.availableTestkits << new AsakusaMapReduceTestkit()
-        sdk.sdk.availableTestkits << new AsakusaSimpleMapReduceTestkit()
+    private void configureTestkit() {
+        AsakusafwSdkExtension sdk = AsakusaSdkPlugin.get(project).sdk
+        sdk.availableTestkits << new AsakusaMapReduceTestkit()
+        sdk.availableTestkits << new AsakusaSimpleMapReduceTestkit()
     }
 
     private void configureConfigurations() {
@@ -107,48 +89,6 @@ class AsakusaMapReduceSdkBasePlugin implements Plugin<Project> {
                 }
             }
         }
-    }
-
-    private Map<String, Object> parseOptions(List<String> options) {
-        Map<String, Object> results = [:]
-        for (String s : options) {
-            if (s == null || s.trim().isEmpty()) {
-                continue
-            }
-            String option = s.trim()
-            Matcher m = OPTION_PATTERN.matcher(option)
-            if (m.matches()) {
-                if (m.group(1) != null) {
-                    String key = m.group(2)
-                    boolean value = m.group(1) == '+'
-                    results[key] = value
-                } else if (m.group(3) != null) {
-                    String key = m.group(3)
-                    String value = m.group(4)
-                    results[key] = value
-                } else {
-                    throw new AssertionError(option)
-                }
-            } else {
-                project.logger.warn "unrecognizable compiler option: ${option}"
-            }
-        }
-        return results
-    }
-
-    /**
-     * Returns the extension object of this plug-in.
-     * The plug-in will be applied automatically.
-     * @param project the target project
-     * @return the related extension
-     */
-    static AsakusafwCompilerExtension get(Project project) {
-        project.apply plugin: AsakusaMapReduceSdkBasePlugin
-        AsakusaMapReduceSdkBasePlugin plugin = project.plugins.getPlugin(AsakusaMapReduceSdkBasePlugin)
-        if (plugin == null) {
-            throw new IllegalStateException('AsakusaMapReduceSdkBasePlugin has not been applied')
-        }
-        return plugin.extension
     }
 
     /**

--- a/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkPlugin.groovy
@@ -62,6 +62,7 @@ class AsakusaMapReduceSdkPlugin implements Plugin<Project> {
     }
 
     private defineCompileBatchappTask() {
+        AsakusaMapReduceBaseExtension base = AsakusaMapReduceBasePlugin.get(project)
         AsakusafwPluginConvention sdk = AsakusaSdkPlugin.get(project)
         project.tasks.create(TASK_COMPILE, CompileBatchappTask) { CompileBatchappTask task ->
             task.group AsakusaSdkPlugin.ASAKUSAFW_BUILD_GROUP
@@ -81,7 +82,7 @@ class AsakusaMapReduceSdkPlugin implements Plugin<Project> {
             task.conventionMapping.with {
                 logbackConf = { sdk.logbackConf ? project.file(sdk.logbackConf) : null }
                 maxHeapSize = { sdk.maxHeapSize }
-                frameworkVersion = { sdk.asakusafwVersion }
+                frameworkVersion = { base.featureVersion }
                 packageName = { sdk.compiler.compiledSourcePackage }
                 compilerOptions = { restoreOptions(extension.compilerProperties) }
                 workingDirectory = {

--- a/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaSimpleMapReduceTestkit.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaSimpleMapReduceTestkit.groovy
@@ -18,6 +18,8 @@ package com.asakusafw.mapreduce.gradle.plugins.internal
 import org.gradle.api.Project
 
 import com.asakusafw.gradle.plugins.AsakusaTestkit
+import com.asakusafw.gradle.plugins.AsakusafwBaseExtension
+import com.asakusafw.gradle.plugins.AsakusafwBasePlugin
 import com.asakusafw.gradle.plugins.AsakusafwPluginConvention
 import com.asakusafw.gradle.plugins.internal.AsakusaSdkPlugin
 
@@ -42,9 +44,9 @@ class AsakusaSimpleMapReduceTestkit implements AsakusaTestkit {
     @Override
     public void apply(Project project) {
         NORMAL.apply project
-        AsakusafwPluginConvention sdk = AsakusaSdkPlugin.get(project)
+        AsakusafwBaseExtension base = AsakusafwBasePlugin.get(project)
         project.dependencies {
-            testCompile "com.asakusafw.sdk:asakusa-sdk-test-emulation:${sdk.asakusafwVersion}"
+            testCompile "com.asakusafw.sdk:asakusa-sdk-test-emulation:${base.frameworkVersion}"
         }
     }
 

--- a/gradle/src/test/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPluginConventionTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPluginConventionTest.groovy
@@ -66,12 +66,8 @@ class AsakusafwOrganizerPluginConventionTest {
     public void defaults() {
         assert convention != null
 
-        try {
-            convention.getAsakusafwVersion()
-            fail()
-        } catch (InvalidUserDataException e) {
-            // ok
-        }
+        project.asakusafwBase.frameworkVersion = 'AFW_TEST'
+        assert convention.asakusafwVersion == project.asakusafwBase.frameworkVersion
         assert convention.assembleDir == "${project.buildDir}/asakusafw-assembly"
         assert convention.directio instanceof DirectIoConfiguration
         assert convention.windgate instanceof WindGateConfiguration
@@ -152,11 +148,12 @@ class AsakusafwOrganizerPluginConventionTest {
      */
     @Test
     public void dev_defaults() {
+        project.asakusafwBase.frameworkVersion = 'AFW_TEST'
         AsakusafwOrganizerProfile profile = convention.profiles.dev
-        convention.asakusafwVersion = 'AFW-TEST'
         assert profile.name == "dev"
         assert profile.asakusafwVersion == convention.asakusafwVersion
         assert profile.assembleDir == "${convention.assembleDir}-dev"
+        // FIXME change archive name
         assert profile.archiveName == "asakusafw-${convention.asakusafwVersion}-dev.tar.gz"
         assert profile.directio.enabled == convention.directio.enabled
         assert profile.windgate.enabled == convention.windgate.enabled
@@ -172,11 +169,12 @@ class AsakusafwOrganizerPluginConventionTest {
      */
     @Test
     public void prod_defaults() {
+        project.asakusafwBase.frameworkVersion = 'AFW_TEST'
         AsakusafwOrganizerProfile profile = convention.profiles.prod
-        convention.asakusafwVersion = 'AFW-TEST'
         assert profile.name == "prod"
         assert profile.asakusafwVersion == convention.asakusafwVersion
         assert profile.assembleDir == "${convention.assembleDir}-prod"
+        // FIXME change archive name
         assert profile.archiveName == "asakusafw-${convention.asakusafwVersion}.tar.gz"
         assert profile.directio.enabled == convention.directio.enabled
         assert profile.windgate.enabled == convention.windgate.enabled
@@ -200,11 +198,9 @@ class AsakusafwOrganizerPluginConventionTest {
         assert profile != null
         assert profile.name == "testProfile"
 
-        convention.asakusafwVersion = 'AFW-TEST'
-        assert profile.asakusafwVersion == convention.asakusafwVersion
-
         convention.assembleDir = 'AFW-TEST'
         assert profile.assembleDir == "${convention.assembleDir}-testProfile"
+        // FIXME change archive name
         assert profile.archiveName == "asakusafw-${convention.asakusafwVersion}-testProfile.tar.gz"
 
         assert profile.directio.enabled == convention.directio.enabled
@@ -238,10 +234,6 @@ class AsakusafwOrganizerPluginConventionTest {
     public void profiles_split() {
         AsakusafwOrganizerProfile profile = convention.profiles.testProfile
 
-        convention.asakusafwVersion = 'AFW-TEST'
-        profile.asakusafwVersion = 'PRF-TEST'
-        assert profile.asakusafwVersion != convention.asakusafwVersion
-
         profile.assembleDir = 'AFW-TEST'
         assert profile.assembleDir != "${convention.assembleDir}-testProfile"
 
@@ -266,14 +258,14 @@ class AsakusafwOrganizerPluginConventionTest {
      */
     @Test
     public void profiles_configure_property() {
-        convention.asakusafwVersion = 'AFW-TEST'
-        convention.profiles.testProfile.asakusafwVersion 'TEST-PROFILE'
+        convention.extension.libraries = ['AFW-TEST']
+        convention.profiles.testProfile.extension.libraries = ['TEST-PROFILE']
         AsakusafwOrganizerProfile profile = convention.profiles.testProfile
         assert profile != null
         assert profile.name == "testProfile"
-        assert profile.asakusafwVersion == 'TEST-PROFILE'
-        assert convention.asakusafwVersion == 'AFW-TEST'
-        assert convention.profiles.other.asakusafwVersion == convention.asakusafwVersion
+        assert profile.extension.libraries == ['TEST-PROFILE']
+        assert convention.extension.libraries == ['AFW-TEST']
+        assert convention.profiles.other.extension.libraries == convention.extension.libraries
     }
 
     /**
@@ -281,16 +273,16 @@ class AsakusafwOrganizerPluginConventionTest {
      */
     @Test
     public void profiles_configure_closure() {
-        convention.asakusafwVersion = 'AFW-TEST'
+        convention.extension.libraries = ['AFW-TEST']
         convention.profiles.testProfile {
-            asakusafwVersion 'TEST-PROFILE'
+            extension.libraries = ['TEST-PROFILE']
         }
         AsakusafwOrganizerProfile profile = convention.profiles.testProfile
         assert profile != null
         assert profile.name == "testProfile"
-        assert profile.asakusafwVersion == 'TEST-PROFILE'
-        assert convention.asakusafwVersion == 'AFW-TEST'
-        assert convention.profiles.other.asakusafwVersion == convention.asakusafwVersion
+        assert profile.extension.libraries == ['TEST-PROFILE']
+        assert convention.extension.libraries == ['AFW-TEST']
+        assert convention.profiles.other.extension.libraries == convention.extension.libraries
     }
 
     /**

--- a/gradle/src/test/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPluginConventionTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPluginConventionTest.groovy
@@ -17,7 +17,6 @@ package com.asakusafw.gradle.plugins
 
 import static org.junit.Assert.*
 
-import org.gradle.api.InvalidUserDataException
 import org.gradle.api.Project
 import org.gradle.testfixtures.ProjectBuilder
 import org.junit.Rule
@@ -329,5 +328,25 @@ class AsakusafwOrganizerPluginConventionTest {
         convention.extension.libraries = ['e0']
         assert convention.extension.libraries.toSet() == ['e0'].toSet()
         assert profile.extension.libraries.toSet() == ['d0', 'd1'].toSet()
+    }
+
+    /**
+     * Test for changing {@code project.asakusafwOrganizer.asakusafwVersion}.
+     */
+    @Test
+    void asakusafwVersion_change() {
+        project.asakusafwBase.frameworkVersion = '0.1.0'
+        convention.asakusafwVersion = 'CHANGED' // ignored
+        assert convention.asakusafwVersion == '0.1.0'
+    }
+
+    /**
+     * Test for changing {@code project.asakusafwOrganizer.profiles.*.asakusafwVersion}.
+     */
+    @Test
+    void profiles_asakusafwVersion_change() {
+        project.asakusafwBase.frameworkVersion = '0.1.0'
+        convention.profiles.testing.asakusafwVersion = 'CHANGED' // ignored
+        assert convention.profiles.testing.asakusafwVersion == '0.1.0'
     }
 }

--- a/gradle/src/test/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPluginTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPluginTest.groovy
@@ -162,4 +162,16 @@ class AsakusafwOrganizerPluginTest extends OrganizerTestRoot {
             assert dependencies(ptask(profile, 'gatherAsakusafw')).contains(task.name)
         }
     }
+
+    /**
+     * Test for {@code project.asakusafwOrganizer.core.version}.
+     */
+    @Test
+    void version() {
+        project.asakusafwBase.frameworkVersion = '__VERSION__'
+        assert project.asakusafwOrganizer.core.version == '__VERSION__'
+        assert project.asakusafwOrganizer.profiles.dev.core.version == '__VERSION__'
+        assert project.asakusafwOrganizer.profiles.prod.core.version == '__VERSION__'
+        assert project.asakusafwOrganizer.profiles.other.core.version == '__VERSION__'
+    }
 }

--- a/gradle/src/test/groovy/com/asakusafw/gradle/plugins/AsakusafwPluginConventionTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/gradle/plugins/AsakusafwPluginConventionTest.groovy
@@ -143,7 +143,16 @@ class AsakusafwPluginConventionTest {
     void asakusafwVersion_transitive() {
         project.asakusafwBase.frameworkVersion = '0.1.0'
         assert convention.asakusafwVersion == '0.1.0'
+    }
 
+    /**
+     * Test for changing {@code project.asakusafw.asakusafwVersion}.
+     */
+    @Test
+    void asakusafwVersion_change() {
+        project.asakusafwBase.frameworkVersion = '0.1.0'
+        convention.asakusafwVersion = 'CHANGED' // ignored
+        assert convention.asakusafwVersion == '0.1.0'
     }
 
     /**

--- a/gradle/src/test/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceOrganizerPluginTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceOrganizerPluginTest.groovy
@@ -104,4 +104,16 @@ class AsakusaMapReduceOrganizerPluginTest extends OrganizerTestRoot {
         checkDependencies('attachComponentMapreduce')
         checkDependencies('attachMapreduceBatchapps')
     }
+
+    /**
+     * Test for {@code project.asakusafwOrganizer.mapreduce.version}.
+     */
+    @Test
+    void version() {
+        project.asakusaMapReduceBase.featureVersion = '__VERSION__'
+        assert project.asakusafwOrganizer.mapreduce.version == '__VERSION__'
+        assert project.asakusafwOrganizer.profiles.dev.mapreduce.version == '__VERSION__'
+        assert project.asakusafwOrganizer.profiles.prod.mapreduce.version == '__VERSION__'
+        assert project.asakusafwOrganizer.profiles.other.mapreduce.version == '__VERSION__'
+    }
 }

--- a/gradle/src/test/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkPluginTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkPluginTest.groovy
@@ -126,11 +126,12 @@ class AsakusaMapReduceSdkPluginTest {
      */
     @Test
     void tasks_mapreduceCompileBatchapps() {
+        AsakusaMapReduceBaseExtension base = AsakusaMapReduceBasePlugin.get(project)
+        base.featureVersion = '__VERSION__'
+
         AsakusafwPluginConvention sdk = project.asakusafw
         sdk.logbackConf 'testing/logback'
         sdk.maxHeapSize '1G'
-
-        sdk.asakusafwVersion 'testing/compiled'
 
         sdk.compiler.compiledSourcePackage 'testing.batchapps'
         sdk.compiler.compilerOptions = ['Xtesting=true', '+e', '-d']
@@ -150,7 +151,7 @@ class AsakusaMapReduceSdkPluginTest {
         assert task.systemProperties.isEmpty()
         assert task.jvmArgs.isEmpty()
 
-        assert task.frameworkVersion == sdk.asakusafwVersion
+        assert task.frameworkVersion == base.featureVersion
         assert task.packageName == sdk.compiler.compiledSourcePackage
         assert task.workingDirectory == project.file(sdk.compiler.compilerWorkDirectory)
         assert task.hadoopWorkingDirectory == sdk.compiler.hadoopWorkDirectory


### PR DESCRIPTION
## Summary

This PR makes `*.asakusafwVersion` properties unmodifiable.

## Background, Problem or Goal of the patch

The following convention objects provide their properties:
* `asakusafw`
* `asakusafwOrganizer`
* `asakusafwOrganizer.profiles.<profile-name>`

Since Asakusa Framework `0.8.0`, changing the above properties has been already deprecated (but it can be changed). These properties now unmodifiable and developers must use module versions defined by the Asakusa Gradle plug-ins.

Note that, application developers still can read the properties, and each property provides the right version. It is not recommended and developers should use `asakusafw.{core,mapreduce,...}.version` property instead of `*.asakusafwVersion`.

## Design of the fix, or a new feature

The following convention properties are also now available:
* `asakusafwOrganizer.core.version`
  * Asakusa Framework core libraries version.
* `asakusafwOrganizer.profiles.<profile-name>.core.version`
  * Asakusa Framework core libraries version.
* `asakusafwOrganizer.mapreduce.version`
  * Asakusa on MapReduce libraries version.
* `asakusafwOrganizer.profiles.<profile-name>.mapreduce.version`
  * Asakusa on MapReduce libraries version.

## Related Issue, Pull Request or Code

* #109 

## Wanted reviewer

@akirakw 