### PR TITLE
Refer internal dependency versions from asakusa-parent.

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -36,16 +36,24 @@ apply plugin: 'eclipse'
 
 configurations {
     deployerJars
+    asakusafw
 }
 
 repositories {
+    if (project.hasProperty('mavenLocal')) {
+        logger.lifecycle 'enabling maven local repository'
+        mavenLocal()
+    }
     mavenCentral()
+    maven { url 'http://asakusafw.s3.amazonaws.com/maven/releases' }
+    maven { url 'http://asakusafw.s3.amazonaws.com/maven/snapshots' }
 }
 
 dependencies {
     compile gradleApi()
     testCompile gradleTestKit()
     testCompile 'junit:junit:4.11'
+    asakusafw "com.asakusafw:asakusa-parent:${parentPom.coreVersion}@pom"
     deployerJars 'org.springframework.build:aws-maven:5.0.0.RELEASE'
 }
 
@@ -73,6 +81,7 @@ processResources {
     File outputFile = new File(destinationDir, 'META-INF/asakusa-gradle/artifact.properties')
     inputs.properties parentPom
     outputs.file outputFile
+    outputs.files configurations.asakusafw
     doLast {
         logger.info "injecting artifact versions: ${parentPom}"
         if (!outputFile.parentFile.exists()) {
@@ -82,6 +91,22 @@ processResources {
         Properties p = new Properties()
         p.put("plugin-version", parentPom.projectVersion)
         p.put("framework-version", parentPom.coreVersion)
+        configurations.asakusafw.each { File pom ->
+            if (pom.name.endsWith('.pom')) {
+                def props = new XmlSlurper().parse(pom)['properties']
+                p.put('slf4j-version', props['slf4j.version'].text())
+                p.put('logback-version', props['logback.version'].text())
+                p.put('jsch-version', props['jsch.version'].text())
+                p.put('gson-version', props['gson.version'].text())
+                p.put('http-client-version', props['httpclient.version'].text())
+                p.put('commons-cli-version', props['commons.cli.version'].text())
+                p.put('commons-codec-version', props['commons.codec.version'].text())
+                p.put('commons-io-version', props['commons.io.version'].text())
+                p.put('common-lang-version', props['commons.lang.version'].text())
+                p.put('commons-logging-version', props['commons.logging.version'].text())
+                p.put('hive-artifact', 'org.apache.hive:hive-exec:' + props['sdk.hive.version'].text())
+            }
+        }
         outputFile.withOutputStream { s ->
             p.store(s, null)
         }

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBasePlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBasePlugin.groovy
@@ -88,15 +88,8 @@ class AsakusafwBasePlugin implements Plugin<Project> {
         driveProperties(ARTIFACT_INFO_PATH, [
             'plugin-version': 'Asakusa Gradle plug-ins',
             'framework-version': 'Asakusa SDK',
-        ])
-        project.logger.info "Asakusa Gradle plug-ins: ${extension.pluginVersion}"
-    }
 
-    private void configureDefaults() {
-        driveProperties(DEFAULTS_INFO_PATH, [
-            'java-version': 'JVM version',
-            'gradle-version': 'recommended Gradle',
-            'embedded-libs-directory': 'embeddedd libraries directory',
+            // internal dependencies
             'slf4j-version': 'SLF4J',
             'logback-version': 'Logback',
             'jsch-version': 'JSch',
@@ -108,6 +101,15 @@ class AsakusafwBasePlugin implements Plugin<Project> {
             'commons-codec-version': 'Commons Codec',
             'commons-logging-version': 'Commons Logging',
             'hive-artifact': 'Hive',
+        ])
+        project.logger.info "Asakusa Gradle plug-ins: ${extension.pluginVersion}"
+    }
+
+    private void configureDefaults() {
+        driveProperties(DEFAULTS_INFO_PATH, [
+            'java-version': 'JVM version',
+            'gradle-version': 'recommended Gradle',
+            'embedded-libs-directory': 'embeddedd libraries directory',
         ])
     }
 

--- a/gradle/src/main/resources/META-INF/asakusa-gradle/defaults.properties
+++ b/gradle/src/main/resources/META-INF/asakusa-gradle/defaults.properties
@@ -2,16 +2,3 @@
 java-version=1.8
 gradle-version=2.14.1
 embedded-libs-directory=src/main/libs
-
-## internal dependencies
-slf4j-version=1.7.10
-logback-version=1.1.3
-jsch-version=0.1.53
-gson-version=2.5
-http-client-version=4.2.5
-commons-cli-version=1.2
-commons-codec-version=1.10
-commons-io-version=2.4
-commons-lang-version=2.6
-commons-logging-version=1.2
-hive-artifact=org.apache.hive:hive-exec:1.1.1


### PR DESCRIPTION
## Summary

This PR enables Asakusa Gradle plug-ins to refer dependency artifact versions from the root pom of `asakusafw` project (a.k.a. Asakusa Framework Parent POM - `asakusafw/pom.xml`). 

## Background, Problem or Goal of the patch

The latest implementation, the Gradle plug-ins have referred artifact versions written in `defaults.properties` which must be maintained manually.

## Design of the fix, or a new feature

We can now generate a artifact version list equivalent of the `defaults.properties` in `build.gradle`, which the build script fetches `asakusafw/pom.xml` and extract version list from it.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 