### PR TITLE
Change naming rule of Asakusa deployment archives.

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -104,7 +104,7 @@ processResources {
                 p.put('commons-io-version', props['commons.io.version'].text())
                 p.put('common-lang-version', props['commons.lang.version'].text())
                 p.put('commons-logging-version', props['commons.logging.version'].text())
-                p.put('hive-artifact', 'org.apache.hive:hive-exec:' + props['sdk.hive.version'].text())
+                p.put('hive-version', props['sdk.hive.version'].text())
             }
         }
         outputFile.withOutputStream { s ->

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBaseExtension.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBaseExtension.groovy
@@ -99,7 +99,7 @@ class AsakusafwBaseExtension {
     String commonsLoggingVersion
 
     /**
-     * The default Hive artifact notation.
+     * The default Hive version.
      */
-    String hiveArtifact
+    String hiveVersion
 }

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBasePlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBasePlugin.groovy
@@ -100,7 +100,7 @@ class AsakusafwBasePlugin implements Plugin<Project> {
             'commons-lang-version': 'Commons Lang',
             'commons-codec-version': 'Commons Codec',
             'commons-logging-version': 'Commons Logging',
-            'hive-artifact': 'Hive',
+            'hive-version': 'Apache Hive',
         ])
         project.logger.info "Asakusa Gradle plug-ins: ${extension.pluginVersion}"
     }

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPlugin.groovy
@@ -105,7 +105,7 @@ class AsakusafwOrganizerPlugin  implements Plugin<Project> {
         convention.hive.conventionMapping.with {
             enabled = { false }
         }
-        convention.hive.defaultLibraries.add(base.hiveArtifact + '@jar')
+        convention.hive.defaultLibraries.add((String) "org.apache.hive:hive-exec:${base.hiveVersion}@jar")
         convention.yaess.conventionMapping.with {
             enabled = { true }
             toolsEnabled = { true }
@@ -129,8 +129,7 @@ class AsakusafwOrganizerPlugin  implements Plugin<Project> {
         }
         convention.profiles.create(PROFILE_NAME_PRODUCTION) { AsakusafwOrganizerProfile profile ->
             profile.conventionMapping.with {
-                // FIXME default archive name
-                archiveName = { (String) "asakusafw-${profile.asakusafwVersion}.tar.gz" }
+                archiveName = { (String) "asakusafw-${project.name}.tar.gz" }
             }
         }
         PluginUtils.deprecateAsakusafwVersion project, 'asakusafwOrganizer', convention
@@ -173,8 +172,7 @@ class AsakusafwOrganizerPlugin  implements Plugin<Project> {
         profile.conventionMapping.with {
             asakusafwVersion = { convention.asakusafwVersion } // ok, this just inherits parent version
             assembleDir = { (String) "${convention.assembleDir}-${profile.name}" }
-            // FIXME default archive name
-            archiveName = { (String) "asakusafw-${profile.asakusafwVersion}-${profile.name}.tar.gz" }
+            archiveName = { (String) "asakusafw-${project.name}-${profile.name}.tar.gz" }
         }
         profile.components.process {
             exclude 'META-INF/**'

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerProfile.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerProfile.groovy
@@ -61,9 +61,8 @@ class AsakusafwOrganizerProfile {
      * The final archive name (should be end with {@code .tar.gz}).
      * <dl>
      *   <dt> Default value: </dt>
-     *     <!-- FIXME: default archive name -->
-     *     <dd> <code>"asakusafw-${asakusafwVersion}-${name}.tar.gz"</code> - except 'prod' profile </dd>
-     *     <dd> <code>"asakusafw-${asakusafwVersion}.tar.gz"</code> - for 'prod' profile </dd>
+     *     <dd> <code>"asakusafw-${project.name}-${name}.tar.gz"</code> - except 'prod' profile </dd>
+     *     <dd> <code>"asakusafw-${project.name}.tar.gz"</code> - for 'prod' profile </dd>
      * </dl>
      */
     String archiveName

--- a/gradle/src/test/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPluginConventionTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPluginConventionTest.groovy
@@ -152,8 +152,7 @@ class AsakusafwOrganizerPluginConventionTest {
         assert profile.name == "dev"
         assert profile.asakusafwVersion == convention.asakusafwVersion
         assert profile.assembleDir == "${convention.assembleDir}-dev"
-        // FIXME change archive name
-        assert profile.archiveName == "asakusafw-${convention.asakusafwVersion}-dev.tar.gz"
+        assert profile.archiveName == "asakusafw-${project.name}-dev.tar.gz"
         assert profile.directio.enabled == convention.directio.enabled
         assert profile.windgate.enabled == convention.windgate.enabled
         assert profile.yaess.enabled == convention.yaess.enabled
@@ -173,8 +172,7 @@ class AsakusafwOrganizerPluginConventionTest {
         assert profile.name == "prod"
         assert profile.asakusafwVersion == convention.asakusafwVersion
         assert profile.assembleDir == "${convention.assembleDir}-prod"
-        // FIXME change archive name
-        assert profile.archiveName == "asakusafw-${convention.asakusafwVersion}.tar.gz"
+        assert profile.archiveName == "asakusafw-${project.name}.tar.gz"
         assert profile.directio.enabled == convention.directio.enabled
         assert profile.windgate.enabled == convention.windgate.enabled
         assert profile.yaess.enabled == convention.yaess.enabled
@@ -199,8 +197,7 @@ class AsakusafwOrganizerPluginConventionTest {
 
         convention.assembleDir = 'AFW-TEST'
         assert profile.assembleDir == "${convention.assembleDir}-testProfile"
-        // FIXME change archive name
-        assert profile.archiveName == "asakusafw-${convention.asakusafwVersion}-testProfile.tar.gz"
+        assert profile.archiveName == "asakusafw-${project.name}-testProfile.tar.gz"
 
         assert profile.directio.enabled == convention.directio.enabled
         convention.directio.enabled = !convention.directio.enabled


### PR DESCRIPTION
## Summary

This PR changes naming rule of Asakusa deployment archives.

## Background, Problem or Goal of the patch

The latest implementation, `assemble` task generates the deployment archives named `asakusafw-${asakusafw.asakusafwVersion}(-${profile.name}).tar.gz`.

## Design of the fix, or a new feature

`assemble` task now generates the deployment archives with the following rule:
* for `prod` profile
  * `asakusafw-${project.name}.tar.gz`
* for other profiles
  * `asakusafw-${project.name}-${profile.name}.tar.gz`

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 