### PR TITLE
Introduce `asakusafw.javac.processorOptions`.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwPluginConvention.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwPluginConvention.groovy
@@ -218,6 +218,33 @@ class AsakusafwPluginConvention {
         void targetCompatibility(Object value) {
             this.targetCompatibility = JavaVersion.toVersion(value)
         }
+
+        /**
+         * The annotation processor options.
+         * @since 0.9.0
+         */
+        Map<Object, Object> processorOptions = [:]
+
+        /**
+         * Adds an annotation processor option pair.
+         * @param key the option key
+         * @param value the option value
+         * @since 0.9.0
+         */
+        void processorOption(Object key, Object value) {
+            getProcessorOptions().put(key, value)
+        }
+
+        /**
+         * Adds a set of annotation processor option pairs.
+         * @param additions the additional processor options
+         * @since 0.9.0
+         */
+        void processorOptions(Map<?, ?> additions) {
+            additions.each { k, v ->
+                processorOption(k, v)
+            }
+        }
     }
 
     /**

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/EclipsePluginEnhancement.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/EclipsePluginEnhancement.groovy
@@ -20,7 +20,9 @@ import groovy.xml.MarkupBuilder
 import org.gradle.api.*
 import org.gradle.plugins.ide.eclipse.EclipsePlugin
 
+import com.asakusafw.gradle.plugins.AsakusafwPluginConvention.JavacConfiguration
 import com.asakusafw.gradle.plugins.internal.PluginUtils
+import com.asakusafw.gradle.tasks.internal.ResolutionUtils
 
 /**
  * Gradle Eclipse plugin enhancements for Asakusa Framework.
@@ -153,10 +155,14 @@ class EclipsePluginEnhancement {
     }
 
     private void generateAptPref() {
+        JavacConfiguration javac = project.asakusafw.javac
         preferences('.settings/org.eclipse.jdt.apt.core.prefs') { Properties props ->
             props.setProperty('org.eclipse.jdt.apt.aptEnabled', 'true')
-            props.setProperty('org.eclipse.jdt.apt.genSrcDir', relativePath(project.asakusafw.javac.annotationSourceDirectory))
+            props.setProperty('org.eclipse.jdt.apt.genSrcDir', relativePath(javac.annotationSourceDirectory))
             props.setProperty('org.eclipse.jdt.apt.reconcileEnabled', 'true')
+            ResolutionUtils.resolveToStringMap(javac.processorOptions).each { String k, String v ->
+                props.setProperty("org.eclipse.jdt.apt.processorOptions/${k}", v)
+            }
         }
     }
 

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
@@ -24,6 +24,7 @@ import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.plugins.JavaPlugin
 import org.gradle.api.tasks.SourceSet
 import org.gradle.api.tasks.bundling.Jar
+import org.gradle.api.tasks.compile.CompileOptions
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.api.tasks.javadoc.Javadoc
 
@@ -46,6 +47,7 @@ import com.asakusafw.gradle.tasks.GenerateTestbookTask
 import com.asakusafw.gradle.tasks.RunBatchappTask
 import com.asakusafw.gradle.tasks.TestToolTask
 import com.asakusafw.gradle.tasks.internal.AbstractTestToolTask
+import com.asakusafw.gradle.tasks.internal.ResolutionUtils
 
 /**
  * A Gradle plug-in for application development project using Asakusa SDK.
@@ -336,8 +338,14 @@ class AsakusaSdkPlugin implements Plugin<Project> {
                     throw new InvalidUserDataException("sourceSets.main.annotations has only upto 1 directory: ${annotations}")
                 }
                 File directory = annotations.iterator().next()
-                project.tasks.compileJava.options.compilerArgs += ['-s', directory.absolutePath, '-Xmaxerrs', '10000']
                 project.tasks.compileJava.inputs.property 'annotationSourceDirectory', directory.absolutePath
+
+                CompileOptions opts = project.tasks.compileJava.options
+                opts.compilerArgs.addAll(['-s', directory.absolutePath])
+                opts.compilerArgs.addAll(['-Xmaxerrs', '10000'])
+                ResolutionUtils.resolveToStringMap(extension.javac.processorOptions).each { String k, String v ->
+                    opts.compilerArgs.add("-A${k}=${v}")
+                }
             }
         }
     }


### PR DESCRIPTION
## Summary

This PR enables Asakusa Gradle plug-ins to pass arguments to annotation processors via a convention property `asakusafw.javac.processorOptions`.

## Background, Problem or Goal of the patch

The original `compileJava` can accept any Java compiler arguments including annotation processors, but its change does not reflect to Eclipse.

## Design of the fix, or a new feature

Application developers also can use the following utility methods on `asakusafw.javac`.

* `processorOption(Object key, Object value)`
  * adds an option pair
* `processorOptions(Map<?, ?> additions)`
  * adds set of option pairs

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 