### PR TITLE
Fix code style.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/assembly/AsakusafwAssembly.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/assembly/AsakusafwAssembly.groovy
@@ -34,12 +34,12 @@ class AsakusafwAssembly implements Buildable {
     /**
      * The assembly definition fragments.
      */
-    final List<AssemblyHandler> handlers = new ArrayList<AssemblyHandler>()
+    final List<AssemblyHandler> handlers = new ArrayList<>()
 
     /**
      * The common extra operations which are available for all handlers in this assembly.
      */
-    final LinkedList<Closure<?>> extraOperations = new LinkedList<Closure<?>>()
+    final LinkedList<Closure<?>> extraOperations = new LinkedList<>()
 
     /**
      * Creates a new instance.

--- a/gradle/src/main/groovy/com/asakusafw/gradle/assembly/AssemblyHandler.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/assembly/AssemblyHandler.groovy
@@ -43,18 +43,18 @@ class AssemblyHandler implements Buildable {
      * Source files and directories.
      * This will be resolved using {@code project.files(...)}.
      */
-    final List<Object> sourceFiles = new ArrayList<Object>()
+    final List<Object> sourceFiles = new ArrayList<>()
 
     /**
      * Source archives in ZIP format.
      * This will be resolved using {@code project.files(...)}.
      */
-    final List<Object> sourceArchives = new ArrayList<Object>()
+    final List<Object> sourceArchives = new ArrayList<>()
 
     /**
      * The extra operations which are only available for this handler.
      */
-    final LinkedList<Closure<?>> extraOperations = new LinkedList<Closure<?>>()
+    final LinkedList<Closure<?>> extraOperations = new LinkedList<>()
 
     /**
      * Creates a new instance.

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPluginConvention.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwOrganizerPluginConvention.groovy
@@ -213,7 +213,7 @@ class AsakusafwOrganizerPluginConvention {
          */
         void setLibraries(Object... libraries) {
             // copy on write
-            List<Object> list = new ArrayList<Object>()
+            List<Object> list = new ArrayList<>()
             list.addAll(libraries.flatten())
             this.@libraries = list
         }
@@ -348,7 +348,7 @@ class AsakusafwOrganizerPluginConvention {
          */
         void setLibraries(Object... libraries) {
             // copy on write
-            List<Object> list = new ArrayList<Object>()
+            List<Object> list = new ArrayList<>()
             list.addAll(libraries.flatten())
             this.@libraries = list
         }

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
@@ -382,7 +382,7 @@ class AsakusaSdkPlugin implements Plugin<Project> {
     }
 
     private void extendVersionsTask() {
-        project.tasks.getByName(AsakusafwBasePlugin.TASK_VERSIONS) << {
+        project.tasks.getByName(AsakusafwBasePlugin.TASK_VERSIONS).doLast {
             AsakusafwBaseExtension base = AsakusafwBasePlugin.get(project)
             logger.lifecycle "Asakusa SDK: ${base.frameworkVersion ?: 'INVALID'}"
             logger.lifecycle "JVM: ${extension.javac.targetCompatibility}"

--- a/gradle/src/main/groovy/com/asakusafw/gradle/tasks/GatherAssemblyTask.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/tasks/GatherAssemblyTask.groovy
@@ -37,7 +37,7 @@ class GatherAssemblyTask extends DefaultTask {
     /**
      * The source assemblies information.
      */
-    final List<AsakusafwAssembly> assemblies = new ArrayList<AsakusafwAssembly>()
+    final List<AsakusafwAssembly> assemblies = new ArrayList<>()
 
     /**
      * The destination base directory.

--- a/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkPlugin.groovy
@@ -188,7 +188,7 @@ class AsakusaMapReduceSdkPlugin implements Plugin<Project> {
     }
 
     private void extendVersionsTask() {
-        project.tasks.getByName(AsakusafwBasePlugin.TASK_VERSIONS) << {
+        project.tasks.getByName(AsakusafwBasePlugin.TASK_VERSIONS).doLast {
             def hadoopVersion = 'UNKNOWN'
             try {
                 logger.info 'detecting Hadoop version'
@@ -208,9 +208,9 @@ class AsakusaMapReduceSdkPlugin implements Plugin<Project> {
     }
 
     private String findHadoopVersion(ResolvedConfiguration conf) {
-        LinkedList<ResolvedDependency> work = new LinkedList<ResolvedDependency>()
+        LinkedList<ResolvedDependency> work = new LinkedList<>()
         work.addAll(conf.firstLevelModuleDependencies)
-        Set<ResolvedDependency> saw = new HashSet<ResolvedDependency>()
+        Set<ResolvedDependency> saw = new HashSet<>()
         while (!work.empty) {
             ResolvedDependency d = work.removeFirst()
             if (saw.contains(d)) {

--- a/gradle/src/test/groovy/com/asakusafw/gradle/tasks/internal/ResolutionUtilsTest.groovy
+++ b/gradle/src/test/groovy/com/asakusafw/gradle/tasks/internal/ResolutionUtilsTest.groovy
@@ -124,7 +124,7 @@ class ResolutionUtilsTest {
      */
     @Test
     public void resolve_map_w_null_key() {
-        Map<Object, Object> origin = new HashMap<Object, Object>()
+        Map<Object, Object> origin = [:]
         origin.put 'k1', 'v1'
         origin.put null, 'v2'
         origin.put 'k3', 'v3'
@@ -138,7 +138,7 @@ class ResolutionUtilsTest {
      */
     @Test
     public void resolve_map_any() {
-        Map<Object, Object> origin = new HashMap<Object, Object>()
+        Map<Object, Object> origin = [:]
         origin.put({ 'k1' }, { 100 })
         origin.put({ 'k2' } as Callable<?>, { null })
         origin.put({ null }, 'v3')


### PR DESCRIPTION
## Summary

This PR fixes code style of Gradle plug-ins.

## Background, Problem or Goal of the patch

`Task.leftShift()` will have become deprecated from Gradle `3.2`.

## Design of the fix, or a new feature

This includes the two following changes:
* using diamond operators instead of explicit type args
* using `Task.doLast()` instead of `Task.leftShift()`

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 