### PR TITLE
Suppress WindGate dependencies in `mapreduce-emulation` testkit.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkBasePlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkBasePlugin.groovy
@@ -64,6 +64,10 @@ class AsakusaMapReduceSdkBasePlugin implements Plugin<Project> {
                 description 'Asakusa DSL testkit classpath for MapReduce'
                 extendsFrom project.configurations.asakusaMapreduceCommon
             }
+            asakusaMapreduceEmulationTestkit {
+                description 'Asakusa DSL testkit classpath for MapReduce Emulator'
+                extendsFrom project.configurations.asakusaMapreduceTestkit
+            }
         }
         PluginUtils.afterEvaluate(project) {
             AsakusaMapReduceBaseExtension base = AsakusaMapReduceBasePlugin.get(project)
@@ -86,6 +90,12 @@ class AsakusaMapReduceSdkBasePlugin implements Plugin<Project> {
                 }
                 if (features.testing) {
                     asakusaMapreduceTestkit "com.asakusafw.mapreduce.compiler:asakusa-mapreduce-compiler-test-adapter:${base.featureVersion}"
+
+                    asakusaMapreduceEmulationTestkit "com.asakusafw:asakusa-test-inprocess:${base.featureVersion}"
+                    asakusaMapreduceEmulationTestkit "com.asakusafw:asakusa-test-windows:${base.featureVersion}"
+                    if (features.windgate) {
+                        asakusaMapreduceEmulationTestkit "com.asakusafw:asakusa-windgate-test-inprocess:${base.featureVersion}"
+                    }
                 }
             }
         }

--- a/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaSimpleMapReduceTestkit.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaSimpleMapReduceTestkit.groovy
@@ -18,10 +18,6 @@ package com.asakusafw.mapreduce.gradle.plugins.internal
 import org.gradle.api.Project
 
 import com.asakusafw.gradle.plugins.AsakusaTestkit
-import com.asakusafw.gradle.plugins.AsakusafwBaseExtension
-import com.asakusafw.gradle.plugins.AsakusafwBasePlugin
-import com.asakusafw.gradle.plugins.AsakusafwPluginConvention
-import com.asakusafw.gradle.plugins.internal.AsakusaSdkPlugin
 
 /**
  * An implementation of {@link AsakusaTestkit} which uses MapReduce compiler and emulation mode runtime.
@@ -43,10 +39,9 @@ class AsakusaSimpleMapReduceTestkit implements AsakusaTestkit {
 
     @Override
     public void apply(Project project) {
-        NORMAL.apply project
-        AsakusafwBaseExtension base = AsakusafwBasePlugin.get(project)
-        project.dependencies {
-            testCompile "com.asakusafw.sdk:asakusa-sdk-test-emulation:${base.frameworkVersion}"
+        project.logger.info "enabling MapReduce (emulation mode) Testkit (${name})"
+        project.configurations {
+            testCompile.extendsFrom asakusaMapreduceEmulationTestkit
         }
     }
 


### PR DESCRIPTION
## Summary

This PR reduces WindGate module dependencies if `mapreduce-emulation` testkit is enabled.

## Background, Problem or Goal of the patch

In release `0.9.0`, `mapreduce-emulation` testkit implicitly activates `asakusa-windgate-test-inprocess`, and it will take WindGate module dependencies.

## Design of the fix, or a new feature

This PR removes a dependency to `com.asakusafw.sdk:asakusa-sdk-test-emulation` in the testkit, which SDK artifact contains `asakusa-windgate-test-inprocess` modules. We individually activate the `asakusa-windgate-test-inprocess` module only if `asakusafw.sdk.windgate` is `true`.

## Related Issue, Pull Request or Code

N/A.

## Wanted reviewer

@akirakw 