### PR TITLE
Expand `asakusafw.sdk` information in Eclipse project settings.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwPluginConvention.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwPluginConvention.groovy
@@ -23,7 +23,7 @@ import org.gradle.api.JavaVersion
 /**
  * Convention class for {@link AsakusafwPlugin}.
  * @since 0.5.2
- * @version 0.9.0
+ * @version 0.9.1
  */
 class AsakusafwPluginConvention {
 
@@ -391,7 +391,8 @@ class AsakusafwPluginConvention {
     private static boolean isConventionMember(Class<?> target) {
         if (target == null || target.isPrimitive() || target == String) {
             return false
-        } else if (AsakusafwPluginConvention.class.isAssignableFrom(target)) {
+        } else if (AsakusafwPluginConvention.class.isAssignableFrom(target)
+                || target == AsakusafwSdkExtension.class) {
             return true
         }
         return isConventionMember(target.getEnclosingClass())


### PR DESCRIPTION
## Summary

This PR expands `asakusafw.sdk` information in Eclipse project settings (`.settings/com.asakusafw.asakusafw.prefs`).

## Background, Problem or Goal of the patch

Using `./gradlew eclipse` task, the Asakusa Gradle plugin generates a project information file into `.settings/com.asakusafw.asakusafw.prefs`. Its `asakusafw.sdk` has been broken since #109.

This PR fixes the above problem, and generates like as following entries (sorted):

```
com.asaksuafw.asakusafw.sdk.availableTestkits=[Testkit(mapreduce-emulation), Testkit(vanilla), Testkit(mapreduce)]
com.asaksuafw.asakusafw.sdk.core=true
com.asaksuafw.asakusafw.sdk.directio=true
com.asaksuafw.asakusafw.sdk.dmdl=true
com.asaksuafw.asakusafw.sdk.hive=false
com.asaksuafw.asakusafw.sdk.operator=NEW
com.asaksuafw.asakusafw.sdk.testing=true
com.asaksuafw.asakusafw.sdk.testkit=vanilla
com.asaksuafw.asakusafw.sdk.windgate=true
```

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

* #109

## Wanted reviewer

@akirakw 