### PR TITLE
Remove to set distributionUrl for using https

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBasePlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBasePlugin.groovy
@@ -202,7 +202,6 @@ class AsakusafwBasePlugin implements Plugin<Project> {
             project.tasks.getByName(TASK_UPGRADE).dependsOn t
             t.conventionMapping.with {
                 gradleVersion = { extension.gradleVersion }
-                distributionUrl = { (String) "http://services.gradle.org/distributions/gradle-${t.gradleVersion}-bin.zip" }
                 jarFile  = { project.file('.buildtools/gradlew.jar') }
             }
             t.doFirst {


### PR DESCRIPTION
## Summary
This PR removes `distribuionUrl` of `.buildtools/gradlew.properties` that is generated by `asakusaUpgrade` task.

## Background, Problem or Goal of the patch

It seems that `http://services.gradle.org/distributions` returns HTTP 301 (Moved Permanently) so when executing `gradlew` command with that distributionUrl, `gradlew` fails with following messages:

```
Exception in thread "main" java.util.zip.ZipException: zip file is empty
	at java.util.zip.ZipFile.open(Native Method)
	at java.util.zip.ZipFile.<init>(ZipFile.java:219)
	at java.util.zip.ZipFile.<init>(ZipFile.java:149)
	at java.util.zip.ZipFile.<init>(ZipFile.java:163)
	at org.gradle.wrapper.Install.unzip(Install.java:215)
	at org.gradle.wrapper.Install.access$600(Install.java:27)
	at org.gradle.wrapper.Install$1.call(Install.java:75)
	at org.gradle.wrapper.Install$1.call(Install.java:48)
	at org.gradle.wrapper.ExclusiveFileAccessManager.access(ExclusiveFileAccessManager.java:69)
	at org.gradle.wrapper.Install.createDist(Install.java:48)
	at org.gradle.wrapper.WrapperExecutor.execute(WrapperExecutor.java:107)
	at org.gradle.wrapper.GradleWrapperMain.main(GradleWrapperMain.java:61)
```

## Design of the fix, or a new feature

Removes to set `distribuionUrl` on `.buildtools/gradlew.properties`.
It will set `https://...` as default value of `distribuionUrl` property.

## Related Issue, Pull Request or Code
* asakusafw/asakusafw-shafu#19
