### PR TITLE
Fix to set distributionUrl for asakusaUpgrade task

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBasePlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/AsakusafwBasePlugin.groovy
@@ -200,8 +200,8 @@ class AsakusafwBasePlugin implements Plugin<Project> {
         project.tasks.create('upgradeGradleWrapper', Wrapper) { Wrapper t ->
             t.description 'Upgrades Gradle wrapper'
             project.tasks.getByName(TASK_UPGRADE).dependsOn t
+            t.gradleVersion = extension.gradleVersion
             t.conventionMapping.with {
-                gradleVersion = { extension.gradleVersion }
                 jarFile  = { project.file('.buildtools/gradlew.jar') }
             }
             t.doFirst {


### PR DESCRIPTION
## Summary
This PR fixes to set `distributionUrl` for `asakusaUpgrade` task

## Background, Problem or Goal of the patch
We think that `org.gradle.api.tasks.wrapper.Wrapper.getDistributionUrl` does not treat Convention Mapping collectly.

* https://github.com/gradle/gradle/blob/master/subprojects/build-init/src/main/groovy/org/gradle/api/tasks/wrapper/Wrapper.java#L314

## Design of the fix, or a new feature
N/A.

## Related Issue, Pull Request or Code
* #129
