### PR TITLE
Fix to include old asm on eclipse classpath

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
@@ -215,6 +215,9 @@ class AsakusaSdkPlugin implements Plugin<Project> {
                     }
                 }
                 if (features.testing) {
+                    // For eclipse classpath
+                    project.configurations.compile.exclude group: 'asm', module: 'asm'
+                    project.configurations.testCompile.exclude group: 'asm', module: 'asm'
                     testCompile "com.asakusafw.sdk:asakusa-sdk-test-core:${base.frameworkVersion}"
                     if (features.directio) {
                         testCompile "com.asakusafw.sdk:asakusa-sdk-test-directio:${base.frameworkVersion}"


### PR DESCRIPTION
## Summary

This PR fixes to include old asm artifact on eclipse classpath when using Gradle 3.4 or later.

## Background, Problem or Goal of the patch

This causes that vanilla testkit fails when running on eclipse junit launcher with following messages:
```
java.lang.IncompatibleClassChangeError: Found interface org.objectweb.asm.MethodVisitor, but class was expected
	at com.asakusafw.dag.compiler.codegen.AsmUtil.defineEmptyConstructor(AsmUtil.java:247)
	at com.asakusafw.dag.compiler.internalio.InternalOutputPrepareGenerator.generate(InternalOutputPrepareGenerator.java:49)
	at com.asakusafw.dag.compiler.flow.DataFlowUtil.lambda$registerInternalOutput$8(DataFlowUtil.java:323)
	at com.asakusafw.dag.compiler.flow.DataFlowUtil.generate(DataFlowUtil.java:187)
...
```

## Design of the fix, or a new feature
Excludes `asm:asm` artifact from `compile` and `testCompile` configuration.

## Related Issue, Pull Request or Code
N/A.