### PR TITLE
Fix task I/O setting in build script.

### DIFF
--- a/gradle/build.gradle
+++ b/gradle/build.gradle
@@ -80,8 +80,8 @@ groovydoc {
 processResources {
     File outputFile = new File(destinationDir, 'META-INF/asakusa-gradle/artifact.properties')
     inputs.properties parentPom
+    inputs.files configurations.asakusafw
     outputs.file outputFile
-    outputs.files configurations.asakusafw
     doLast {
         logger.info "injecting artifact versions: ${parentPom}"
         if (!outputFile.parentFile.exists()) {


### PR DESCRIPTION
## Summary

This PR fixes task I/O setting in the `./gradle` project's build script.

## Background, Problem or Goal of the patch

The latest script does not work in Gradle `4.0-milestone-2`. The root `pom.xml` file of `asakusafw` project must be an input of the task that generates `artifact.properties` file.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.