### PR TITLE
Avoid using deprecated methods since Gradle 4.0.

### DIFF
--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/AsakusaSdkPlugin.groovy
@@ -463,7 +463,7 @@ class AsakusaSdkPlugin implements Plugin<Project> {
             task.description 'Generates a Hive DDL file [Experimental].'
             task.toolClasspath += project.configurations.asakusaHiveCli
             task.toolClasspath += project.sourceSets.main.compileClasspath
-            task.sourcepath = project.files({ project.sourceSets.main.output.classesDir })
+            task.sourcepath = PluginUtils.getClassesDirs(project, project.sourceSets.main.output)
             task.conventionMapping.with {
                 logbackConf = { this.findLogbackConf() }
                 maxHeapSize = { extension.maxHeapSize }

--- a/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/PluginUtils.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/gradle/plugins/internal/PluginUtils.groovy
@@ -23,9 +23,11 @@ import org.gradle.api.NamedDomainObjectContainer
 import org.gradle.api.Project
 import org.gradle.api.ProjectState
 import org.gradle.api.Task
+import org.gradle.api.file.FileCollection
 import org.gradle.api.plugins.Convention
 import org.gradle.api.plugins.ExtensionAware
 import org.gradle.api.plugins.ExtensionContainer
+import org.gradle.api.tasks.SourceSetOutput
 import org.gradle.util.ConfigureUtil
 import org.gradle.util.GradleVersion
 
@@ -34,7 +36,7 @@ import com.asakusafw.gradle.plugins.PluginParticipant
 /**
  * Basic utilities for Gradle plug-ins.
  * @since 0.7.4
- * @version 0.9.1
+ * @version 0.9.2
  */
 final class PluginUtils {
 
@@ -291,6 +293,21 @@ final class PluginUtils {
                     return ConfigureUtil.configure(arguments[0], container.maybeCreate(methodName))
                 }
             }
+        }
+    }
+
+    /**
+     * Returns a set of class files output directories.
+     * @param project the current project
+     * @param output the target output
+     * @return the set of class files output directories
+     * @since 0.9.2
+     */
+    public static FileCollection getClassesDirs(Project project, SourceSetOutput output) {
+        if (output.hasProperty('classesDirs')) {
+            return output.classesDirs
+        } else {
+            return project.files({ output.classesDir })
         }
     }
 

--- a/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkPlugin.groovy
+++ b/gradle/src/main/groovy/com/asakusafw/mapreduce/gradle/plugins/internal/AsakusaMapReduceSdkPlugin.groovy
@@ -116,7 +116,7 @@ class AsakusaMapReduceSdkPlugin implements Plugin<Project> {
             task.dependsOn project.tasks.classes
             task.compilerName = 'Asakusa DSL compiler for MapReduce'
 
-            task.sourcepath << { project.sourceSets.main.output.classesDir }
+            task.sourcepath << PluginUtils.getClassesDirs(project, project.sourceSets.main.output)
             task.embed << { project.sourceSets.main.output.resourcesDir }
 
             task.toolClasspath << project.configurations.asakusaMapreduceCompiler


### PR DESCRIPTION
## Summary

This PR replaces uses of Gradle API which will be deprecated since Gradle 4.0.

## Background, Problem or Goal of the patch

`SourceSetOutput.getClassesDir()` will have been deprecated since Gradle 4.0, and be replaced with `..getClassesDirs()`.

## Design of the fix, or a new feature

N/A.

## Related Issue, Pull Request or Code

N/A.